### PR TITLE
fix: fix instagram click link from timi to official

### DIFF
--- a/src/components/Footer/Channels/Channels.tsx
+++ b/src/components/Footer/Channels/Channels.tsx
@@ -20,7 +20,7 @@ function Channels({ isFooter = false }: ChannelsProps) {
         window.open('https://www.facebook.com/clubsopt/');
         break;
       case 'instagram':
-        window.open('https://www.instagram.com/sopt_timi_tmi/');
+        window.open('https://www.instagram.com/sopt_official/');
         break;
       case 'youtube':
         window.open('https://www.youtube.com/c/SOPTMEDIA');


### PR DESCRIPTION
### PR 요약

- 현재 하단 인스타그램 버튼을 누르면 운영팀 인스타그램 계정이 연결됨

### 체크리스트

- [x] 운영팀 인스타 계정 -> 솝트 공식계정 링크로 변경

