### PR TITLE
Fix/#36 이미지 도메인 추가 및 LinkType 수정

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -5,7 +5,11 @@ const nextConfig = {
     ignoreDuringBuilds: true,
   },
   images: {
-    domains: ['sopt-makers.s3.ap-northeast-2.amazonaws.com'],
+    domains: [
+      'sopt-makers.s3.ap-northeast-2.amazonaws.com',
+      's3.ap-northeast-2.amazonaws.com',
+      'user-images.githubusercontent.com',
+    ],
   },
   webpack: (config) => {
     config.module.rules.push({

--- a/src/views/ProjectDetailPage/types.ts
+++ b/src/views/ProjectDetailPage/types.ts
@@ -10,12 +10,12 @@ export interface LinkType {
 }
 
 export type LinkDetailType =
-  | '웹사이트'
-  | '앱 스토어'
-  | '구글 플레이스토어'
-  | 'Github'
+  | 'website'
+  | 'appStore'
+  | 'googlePlay'
+  | 'github'
   | 'instagram'
-  | '발표영상';
+  | 'media';
 
 export interface UpButtonProps {
   isScrolled: boolean;

--- a/src/views/ProjectDetailPage/utils/getLinkNameAndSrcWithType.ts
+++ b/src/views/ProjectDetailPage/utils/getLinkNameAndSrcWithType.ts
@@ -7,12 +7,12 @@ import website from '@src/assets/icons/website_icon.svg';
 import { LinkDetailType } from '../types';
 
 const LinkMap = {
-  웹사이트: { name: '웹사이트', src: website },
-  '구글 플레이스토어': { name: '플레이스토어', src: googleplay },
-  '앱 스토어': { name: '앱스토어', src: appstore },
-  Github: { name: 'Github', src: github },
+  website: { name: '웹사이트', src: website },
+  googlePlay: { name: '플레이스토어', src: googleplay },
+  appStore: { name: '앱스토어', src: appstore },
+  github: { name: 'Github', src: github },
   instagram: { name: '인스타그램', src: instagram },
-  발표영상: { name: '발표영상', src: media },
+  media: { name: '발표영상', src: media },
 };
 
 export const getLinkNameAndSrcWithType = (title: LinkDetailType) => {

--- a/src/views/ProjectPage/types.ts
+++ b/src/views/ProjectPage/types.ts
@@ -1,11 +1,11 @@
 export enum LinkType {
-  웹사이트 = '웹사이트',
-  발표영상 = '발표영상',
-  Github = 'Github',
+  웹사이트 = 'website',
+  발표영상 = 'media',
+  Github = 'github',
   instagram = 'instagram',
-  '구글 플레이스토어' = '구글 플레이스토어',
-  '앱 스토어' = '앱 스토어',
-  '기타 관련자료' = '기타 관련자료',
+  '구글 플레이스토어' = 'googlePlay',
+  '앱 스토어' = 'appStore',
+  '기타 관련자료' = 'media',
 }
 
 export interface ProjectType {


### PR DESCRIPTION
### PR 요약

### 체크리스트

- [x] 이미지 도메인 추가
```js
images: {
    domains: [
      'sopt-makers.s3.ap-northeast-2.amazonaws.com',
      's3.ap-northeast-2.amazonaws.com',
      'user-images.githubusercontent.com',
    ],
  },
```

- [x] 리스트뷰 LinkRender에서 LinkType value값, 상세뷰 LinkMap key값 수정된 명세서에 맞게 변경
![image](https://user-images.githubusercontent.com/66051416/203909564-ffa85796-cf7c-48e2-bb00-0e7e5fcfe4f5.png)


### Screenshot

### 궁금한 점 및 코멘트
