### PR TITLE
메인 페이지 기획 QA 반영 및 누락된 디자인 가이드 반영

### DIFF
--- a/src/hooks/useIsDesktop.ts
+++ b/src/hooks/useIsDesktop.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useMediaQuery } from 'react-responsive';
 
-export function useIsDesktop(minWidth = '1280px') {
+export function useIsDesktop(minWidth = '1920px') {
   const [isDesktop, setIsDesktop] = useState(true);
   const desktop = useMediaQuery({
     query: `(min-width: ${minWidth})`,
@@ -12,13 +12,24 @@ export function useIsDesktop(minWidth = '1280px') {
   return isDesktop;
 }
 
-export function useIsTablet(minWidth = '766px', maxWidth = '1280px') {
+export function useIsTablet(minWidth = '766px', maxWidth = '1919px') {
   const [isTablet, setIsTablet] = useState(true);
   const tablet = useMediaQuery({
-    query: `(min-width: ${minWidth}), max-width:${maxWidth}`,
+    query: `(min-width: ${minWidth}) and (max-width: ${maxWidth})`,
   });
   useEffect(() => {
     setIsTablet(tablet);
   }, [tablet]);
   return isTablet;
+}
+
+export function useIsMobile(maxWidth = '765px') {
+  const [isMobile, setIsMobile] = useState(true);
+  const mobile = useMediaQuery({
+    query: `max-width:${maxWidth}`,
+  });
+  useEffect(() => {
+    setIsMobile(mobile);
+  }, [mobile]);
+  return isMobile;
 }

--- a/src/views/MainPage/components/ActivityDescription/ActivityDescription.tsx
+++ b/src/views/MainPage/components/ActivityDescription/ActivityDescription.tsx
@@ -1,5 +1,5 @@
 import Image from 'next/image';
-import { useIsDesktop } from '@src/hooks/useIsDesktop';
+import { useIsDesktop, useIsMobile, useIsTablet } from '@src/hooks/useIsDesktop';
 import appJamImage from '@src/views/MainPage/assets/sopt-activity/appjam.png';
 import managementMediaTeamImage from '@src/views/MainPage/assets/sopt-activity/management-media-team.png';
 import seminarImage from '@src/views/MainPage/assets/sopt-activity/seminar.png';
@@ -122,13 +122,15 @@ function DesktopActivityDescription() {
 }
 
 export function ActivityDescription() {
+  const isMobile = useIsMobile();
+  const isTablet = useIsTablet();
   const isDesktop = useIsDesktop();
-  const isMobile = !isDesktop;
 
   return (
     <section className={styles.container}>
       <h3 className={styles.title}>SOPT에서는 이렇게 다양한 활동을 하고 있어요.</h3>
       {isMobile && <MobileActivityDescription />}
+      {isTablet && <DesktopActivityDescription />}
       {isDesktop && <DesktopActivityDescription />}
     </section>
   );

--- a/src/views/MainPage/components/ActivityDescription/activity-description.module.scss
+++ b/src/views/MainPage/components/ActivityDescription/activity-description.module.scss
@@ -133,7 +133,6 @@
 .imageWrapper {
   position: relative;
   border-radius: 10px;
-
   @include mobile {
     width: 328px;
     height: 166px;
@@ -157,31 +156,30 @@
   position: absolute;
   display: flex;
   align-items: center;
+  justify-content: center;
+  flex-direction: column;
   z-index: 2;
   color: #ffffff;
   white-space: nowrap;
 
   @include mobile {
-    width: 79px;
-    height: 38px;
-    flex-direction: column;
-    top: 22%;
-    left: 38%;
+    width: 328px;
+    height: 166px;
+    top: 0;
+    left: 0;
   }
   @include tablet {
-    width: 79px;
-    height: 38px;
-    flex-direction: column;
-    top: 22%;
-    left: 45%;
+    width: 586px;
+    height: 308px;
+    left: 0;
+    top: 0;
   }
   @include desktop {
-    width: 150px;
-    top: 45%;
-    left: 16%;
-    &.nickNameInclude {
-      left: 17%;
-    }
+    flex-direction: row;
+    width: 585px;
+    height: 308px;
+    left: 0;
+    top: 0;
   }
 
   .type {
@@ -191,7 +189,7 @@
       font-size: 18px;
     }
     @include tablet {
-      font-size: 40px;
+      font-size: 30px;
     }
     @include desktop {
       font-size: 40px;
@@ -207,13 +205,14 @@
     }
     @include tablet {
       margin-top: 16px;
-      font-size: 40px;
+      font-size: 24px;
+      font-weight: 600;
     }
     @include desktop {
-      font-weight: 500;
-      font-size: 25px;
       margin-top: 16px;
       margin-left: 4px;
+      font-size: 24px;
+      font-weight: 600;
     }
   }
 }

--- a/src/views/MainPage/components/ActivityDescription/activity-description.module.scss
+++ b/src/views/MainPage/components/ActivityDescription/activity-description.module.scss
@@ -53,9 +53,6 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  @include desktop {
-    gap: 30px;
-  }
 }
 
 .activityList {
@@ -119,7 +116,8 @@
     align-items: center;
     width: 585px;
     height: 632px;
-    gap: 16px;
+    gap: 8px;
+    margin-bottom: 16px;
   }
   @include desktop {
     justify-content: center;
@@ -127,6 +125,7 @@
     width: 1200px;
     height: 308px;
     gap: 30px;
+    margin-bottom: 16px;
   }
 }
 

--- a/src/views/MainPage/components/BannerImage/BannerImage.tsx
+++ b/src/views/MainPage/components/BannerImage/BannerImage.tsx
@@ -8,7 +8,7 @@ export function BannerImage() {
   const containerRef = useRef<HTMLDivElement>(null);
   const onScrollMoveDown = () => {
     if (containerRef.current) {
-      const containerHeight = containerRef.current?.getBoundingClientRect().height;
+      const { height: containerHeight } = containerRef.current.getBoundingClientRect();
       window.scrollTo(0, containerHeight);
     }
   };

--- a/src/views/MainPage/components/BannerImage/BannerImage.tsx
+++ b/src/views/MainPage/components/BannerImage/BannerImage.tsx
@@ -1,14 +1,23 @@
 import Image from 'next/image';
+import { useRef } from 'react';
 import MainPageBanner from '@src/assets/sopt/main-page_banner.png';
 import { ReactComponent as ArrowDown } from '@src/views/MainPage/assets/arrow-down.svg';
 import styles from './banner-image.module.scss';
 
 export function BannerImage() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const onScrollMoveDown = () => {
+    if (containerRef.current) {
+      const containerHeight = containerRef.current?.getBoundingClientRect().height;
+      window.scrollTo(0, containerHeight);
+    }
+  };
+
   return (
-    <section className={styles.container}>
+    <section className={styles.container} ref={containerRef}>
       <p className={styles.description}>기획자, 디자이너, 개발자가 협업을 통해 성장하는 SOPT</p>
       <p className={styles.slogan}>SHOUT OUR PASSION TOGETHER</p>
-      <div className={styles.downArrowWrapper}>
+      <div className={styles.downArrowWrapper} onClick={onScrollMoveDown}>
         <ArrowDown className={styles.downArrow} width="24" height="24" />
       </div>
       <Image

--- a/src/views/MainPage/components/CorporateLinkedActivities/CorporateLinkedActivities.tsx
+++ b/src/views/MainPage/components/CorporateLinkedActivities/CorporateLinkedActivities.tsx
@@ -12,7 +12,7 @@ export function CorporateLinkedActivities() {
     onClickRightButton,
     isLeftScrollable,
     isRightScrollable,
-  } = useHorizontalScroll(1080, 2);
+  } = useHorizontalScroll(930, 2);
 
   return (
     <section className={styles.container}>

--- a/src/views/MainPage/components/CorporateLinkedActivities/constants.ts
+++ b/src/views/MainPage/components/CorporateLinkedActivities/constants.ts
@@ -51,7 +51,7 @@ export const corporatedLinkedActivities = [
   },
   {
     year: 2018,
-    name: '청년창업 컨퍼런스 ATTENTION',
+    name: '청년창업 컨퍼런스',
     description:
       '창업계 연사들을 초청하여 창업과 기술혁신으로 더 나은 세상을 만들어가는 과정에 대해 다룬 컨퍼런스',
     subDescription: '이승건 비바리퍼블리카(토스) 대표 연사로 참석',

--- a/src/views/MainPage/components/CorporateLinkedActivities/corporate-linked-activities.module.scss
+++ b/src/views/MainPage/components/CorporateLinkedActivities/corporate-linked-activities.module.scss
@@ -99,7 +99,6 @@
   display: grid;
   grid-template-rows: repeat(1, 1fr);
   grid-template-columns: repeat(9, 1fr);
-
   @include mobile {
     overflow-x: scroll;
     height: 384px;
@@ -112,27 +111,9 @@
   }
   @include desktop {
     overflow-x: hidden;
-    max-width: 1080px;
+    max-width: 910px;
     height: 700px;
-    gap: 60px;
-  }
-}
-
-.arrowWrapper {
-  @include mobile {
-    display: none;
-  }
-  @include tablet {
-    display: none;
-  }
-  @include desktop {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    width: 64px;
-    height: 64px;
-    border-radius: 50%;
-    border: 1px solid rgba(255, 255, 255, 0.1);
+    gap: 76px;
   }
 }
 
@@ -140,7 +121,6 @@
   position: relative;
   display: flex;
   flex-direction: column;
-
   @include mobile {
     width: 171px;
     height: 384px;
@@ -152,7 +132,7 @@
     gap: 16px;
   }
   @include desktop {
-    width: 301px;
+    width: 240px;
     height: 700px;
     gap: 16px;
   }
@@ -188,7 +168,7 @@
     line-height: 31px;
   }
   @include desktop {
-    font-size: 25px;
+    font-size: 22px;
     line-height: 31px;
   }
 }
@@ -198,7 +178,6 @@
   opacity: 0.8;
   font-weight: 500;
   word-break: keep-all;
-
   @include mobile {
     font-size: 12px;
     line-height: 20px;
@@ -208,8 +187,8 @@
     line-height: 160%;
   }
   @include desktop {
-    font-size: 25px;
-    line-height: 31px;
+    font-size: 20px;
+    line-height: 160%;
   }
 }
 
@@ -242,7 +221,25 @@
     height: 300px;
   }
   @include desktop {
-    width: 300px;
-    height: 300px;
+    width: 240px;
+    height: 240px;
+  }
+}
+
+.arrowWrapper {
+  @include mobile {
+    display: none;
+  }
+  @include tablet {
+    display: none;
+  }
+  @include desktop {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 64px;
+    height: 64px;
+    border-radius: 50%;
+    border: 1px solid rgba(255, 255, 255, 0.1);
   }
 }

--- a/src/views/MainPage/components/CorporatePartner/CorporatePartner.tsx
+++ b/src/views/MainPage/components/CorporatePartner/CorporatePartner.tsx
@@ -2,7 +2,6 @@ import Image from 'next/image';
 import { ReactComponent as ArrowLeft } from '@src/views/MainPage/assets/arrow-left-28x28.svg';
 import { ReactComponent as ArrowRight } from '@src/views/MainPage/assets/arrow-right-28x28.svg';
 import { useHorizontalScroll } from '@src/views/MainPage/lib';
-import cc from 'classcat';
 import { corporatePartnerList } from './constants';
 import styles from './corporate-partner.module.scss';
 

--- a/src/views/MainPage/components/CorporatePartner/corporate-partner.module.scss
+++ b/src/views/MainPage/components/CorporatePartner/corporate-partner.module.scss
@@ -29,6 +29,7 @@
     line-height: 56px;
   }
   @include desktop {
+    width: 100%;
     font-size: 45px;
     line-height: 60px;
   }

--- a/src/views/MainPage/components/DetailedInformation/detailed-information.module.scss
+++ b/src/views/MainPage/components/DetailedInformation/detailed-information.module.scss
@@ -85,6 +85,7 @@
 
 .nameWrapper {
   display: flex;
+  align-items: center;
   @include mobile {
     margin-bottom: 8px;
   }

--- a/src/views/MainPage/components/PartDescription/PartDescription.tsx
+++ b/src/views/MainPage/components/PartDescription/PartDescription.tsx
@@ -1,4 +1,4 @@
-import { useIsDesktop } from '@src/hooks/useIsDesktop';
+import { useIsDesktop, useIsMobile, useIsTablet } from '@src/hooks/useIsDesktop';
 import { useTabs } from '@src/views/MainPage/lib';
 import cc from 'classcat';
 import styles from './part-description.module.scss';
@@ -80,7 +80,8 @@ function DesktopPartDescription() {
 
 export function PartDescription() {
   const isDesktop = useIsDesktop();
-  const isMobile = !isDesktop;
+  const isTablet = useIsTablet();
+  const isMobile = useIsMobile();
 
   return (
     <section className={styles.container}>
@@ -90,6 +91,7 @@ export function PartDescription() {
       </h3>
       <h5 className={styles.subTitle}>*2022년 하반기 31기 기준</h5>
       {isMobile && <MobilePartDescription />}
+      {isTablet && <DesktopPartDescription />}
       {isDesktop && <DesktopPartDescription />}
     </section>
   );

--- a/src/views/MainPage/components/PartDescription/part-description.module.scss
+++ b/src/views/MainPage/components/PartDescription/part-description.module.scss
@@ -144,6 +144,7 @@
     align-items: center;
     width: 100%;
     height: 246px;
+    padding: 63px 56px;
     margin-top: 16px;
   }
 

--- a/src/views/MainPage/components/PartDescription/part-description.module.scss
+++ b/src/views/MainPage/components/PartDescription/part-description.module.scss
@@ -22,7 +22,6 @@
   flex-direction: column;
   white-space: nowrap;
   justify-content: center;
-  text-align: center;
   font-weight: 800;
 
   @include mobile {
@@ -30,15 +29,17 @@
     height: 56px;
     font-size: 20px;
     line-height: 28px;
+    text-align: center;
   }
   @include tablet {
     width: 338px;
     height: 112px;
     font-size: 36px;
     line-height: 56px;
+    text-align: center;
   }
   @include desktop {
-    width: 422px;
+    width: 100%;
     height: 120px;
     font-size: 45px;
     line-height: 60px;
@@ -63,7 +64,7 @@
     margin-top: 24px;
   }
   @include desktop {
-    width: 264px;
+    width: 100%;
     height: 30px;
     font-size: 25px;
     line-height: 30px;


### PR DESCRIPTION
## Summary
- 이미지 배너 아래 화살표 클릭 시 스크롤 이동
- 파트 소개 패딩 값 적용 (by 정연)
- SOPT 활동 이미지 설명 글 가운데 정렬 맞추기
- 파트소개, 활동소개 좌측 정렬
- 화살표 세로 가운데 정렬
- SOPT와 함께한 기업 연계 활동 디자인 가이드 반영

## Comment
메인 페이지 이미지 배경색 그라데이션 적용이 필요합니다. 