### PR TITLE
useDevice hook들의 초기값을 false로 변경

### DIFF
--- a/src/hooks/useDevice.ts
+++ b/src/hooks/useDevice.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { useMediaQuery } from 'react-responsive';
 
 export function useIsDesktop(minWidth = '1920px') {
-  const [isDesktop, setIsDesktop] = useState(true);
+  const [isDesktop, setIsDesktop] = useState(false);
   const desktop = useMediaQuery({
     query: `(min-width: ${minWidth})`,
   });
@@ -13,7 +13,7 @@ export function useIsDesktop(minWidth = '1920px') {
 }
 
 export function useIsTablet(minWidth = '766px', maxWidth = '1919px') {
-  const [isTablet, setIsTablet] = useState(true);
+  const [isTablet, setIsTablet] = useState(false);
   const tablet = useMediaQuery({
     query: `(min-width: ${minWidth}) and (max-width: ${maxWidth})`,
   });
@@ -24,7 +24,7 @@ export function useIsTablet(minWidth = '766px', maxWidth = '1919px') {
 }
 
 export function useIsMobile(maxWidth = '765px') {
-  const [isMobile, setIsMobile] = useState(true);
+  const [isMobile, setIsMobile] = useState(false);
   const mobile = useMediaQuery({
     query: `(max-width:${maxWidth})`,
   });


### PR DESCRIPTION
## Summary
- true로 지정하면 메인 페이지 첫 로딩 시 desktop, tablet, mobile에 대한 헤더가 동시에 보이는 이슈 발생

