### PR TITLE
Feat/#76 header review tap

### DIFF
--- a/src/components/Header/Desktop/DesktopHeader.tsx
+++ b/src/components/Header/Desktop/DesktopHeader.tsx
@@ -1,36 +1,18 @@
 import styled from '@emotion/styled';
-import { useRouter } from 'next/router';
 import logoIcon from '@src/assets/sopt/logo.png';
+import useHeader from '@src/hooks/useHeader';
 
 function DesktopHeader({ menuList }: { menuList: { id: string; title: string }[] }) {
-  const router = useRouter();
-
-  const handleClick = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
-    const currentMenu = e.currentTarget.id;
-
-    if (currentMenu === '/review') {
-      return window.open('https://sopt-official-review.oopy.io/');
-    }
-    if (currentMenu === '/recruit') {
-      return window.open('https://sopt-recruiting.web.app/recruiting/apply/yb');
-    }
-
-    router.push(currentMenu);
-  };
-
-  const handleIsSelected = (path: string) => {
-    if (path.includes('project') && router.pathname.includes('project')) return true;
-    return router.pathname === path;
-  };
+  const { handleClickLogo, handleClickTap, handleIsSelected } = useHeader();
 
   return (
     <Wrapper>
       <CenterAligner>
-        <Logo src={logoIcon.src} onClick={() => router.push('/')} />
+        <Logo src={logoIcon.src} onClick={handleClickLogo} />
       </CenterAligner>
       <MenuTitlesWrapper>
         {menuList.map(({ id, title }) => (
-          <MenuTitle key={id} id={id} isSelected={handleIsSelected(id)} onClick={handleClick}>
+          <MenuTitle key={id} id={id} isSelected={handleIsSelected(id)} onClick={handleClickTap}>
             {title}
           </MenuTitle>
         ))}

--- a/src/components/Header/Desktop/DesktopHeader.tsx
+++ b/src/components/Header/Desktop/DesktopHeader.tsx
@@ -8,9 +8,13 @@ function DesktopHeader({ menuList }: { menuList: { id: string; title: string }[]
   const handleClick = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
     const currentMenu = e.currentTarget.id;
 
+    if (currentMenu === '/review') {
+      return window.open('https://sopt-official-review.oopy.io/');
+    }
     if (currentMenu === '/recruit') {
       return window.open('https://sopt-recruiting.web.app/recruiting/apply/yb');
     }
+
     router.push(currentMenu);
   };
 

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -5,6 +5,7 @@ import styles from './header.module.scss';
 
 const menuList = [
   { id: '/project', title: '프로젝트' },
+  { id: '/review', title: '활동후기' },
   { id: '/FAQ', title: '문의하기' },
   { id: '/recruit', title: '리크루팅' },
 ];

--- a/src/components/Header/Mobile/HeaderMenu.tsx
+++ b/src/components/Header/Mobile/HeaderMenu.tsx
@@ -32,10 +32,14 @@ function HeaderMenu({ menuList, isMenuShown, handleHeaderToggleButton }: HeaderM
   const handleClick = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
     const currentMenu = e.currentTarget.id;
 
+    if (currentMenu === '/review') {
+      return window.open('https://sopt-official-review.oopy.io/');
+    }
     if (currentMenu === '/recruit') {
       window.open('https://sopt-recruiting.web.app/recruiting/apply/yb');
       return;
     }
+
     router.push(currentMenu);
   };
 

--- a/src/components/Header/Mobile/HeaderMenu.tsx
+++ b/src/components/Header/Mobile/HeaderMenu.tsx
@@ -1,5 +1,5 @@
-import { useRouter } from 'next/router';
 import React, { useEffect } from 'react';
+import useHeader from '@src/hooks/useHeader';
 import * as S from './HeaderMenu.style';
 
 type MenuType = 'idle' | 'open' | 'close';
@@ -27,28 +27,9 @@ interface HeaderMenuProps {
 }
 
 function HeaderMenu({ menuList, isMenuShown, handleHeaderToggleButton }: HeaderMenuProps) {
-  const router = useRouter();
-
-  const handleClick = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
-    const currentMenu = e.currentTarget.id;
-
-    if (currentMenu === '/review') {
-      return window.open('https://sopt-official-review.oopy.io/');
-    }
-    if (currentMenu === '/recruit') {
-      window.open('https://sopt-recruiting.web.app/recruiting/apply/yb');
-      return;
-    }
-
-    router.push(currentMenu);
-  };
-
-  const handleIsSelected = (path: string) => {
-    if (path.includes('project') && router.pathname.includes('project')) return true;
-    return router.pathname === path;
-  };
-
   useNoScroll(isMenuShown);
+
+  const { handleClickTap, handleIsSelected } = useHeader();
 
   return (
     <S.Root isMenuShown={isMenuShown}>
@@ -56,7 +37,12 @@ function HeaderMenu({ menuList, isMenuShown, handleHeaderToggleButton }: HeaderM
         <S.ContentsWrap>
           <S.MenuTitlesWrap>
             {menuList.map(({ id, title }) => (
-              <S.MenuTitle key={id} id={id} isSelected={handleIsSelected(id)} onClick={handleClick}>
+              <S.MenuTitle
+                key={id}
+                id={id}
+                isSelected={handleIsSelected(id)}
+                onClick={handleClickTap}
+              >
                 {title}
               </S.MenuTitle>
             ))}

--- a/src/hooks/useHeader.ts
+++ b/src/hooks/useHeader.ts
@@ -1,0 +1,30 @@
+import { useRouter } from 'next/router';
+
+function useHeader() {
+  const router = useRouter();
+
+  const handleClickLogo = () => router.push('/');
+
+  const handleClickTap = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
+    const currentMenu = e.currentTarget.id;
+
+    if (currentMenu === '/review') {
+      return window.open('https://sopt-official-review.oopy.io/');
+    }
+    if (currentMenu === '/recruit') {
+      return window.open('https://sopt-recruiting.web.app/recruiting/apply/yb');
+    }
+
+    router.push(currentMenu);
+  };
+
+  const handleIsSelected = (path: string) => {
+    if (path.includes('project') && router.pathname.includes('project')) return true;
+    return router.pathname === path;
+  };
+
+  return { handleClickLogo, handleClickTap, handleIsSelected };
+
+}
+
+export default useHeader;

--- a/src/pages/review.tsx
+++ b/src/pages/review.tsx
@@ -1,0 +1,1 @@
+export { default } from '@src/views/ReviewPage';

--- a/src/views/ReviewPage/ReviewPage.tsx
+++ b/src/views/ReviewPage/ReviewPage.tsx
@@ -1,0 +1,30 @@
+import styled from '@emotion/styled';
+import { Footer, Header, Layout } from '@src/components';
+
+function ReviewPage() {
+  return (
+    <Layout>
+      <Header />
+      <Root>hello</Root>
+      <Footer />
+    </Layout>
+  );
+}
+
+export default ReviewPage;
+
+const Root = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 1200px;
+  margin: 0 auto;
+
+  /* 태블릿 뷰 */
+  @media (max-width: 1919px) and (min-width: 766px) {
+    width: 766px;
+  }
+  /* 모바일 뷰 */
+  @media (max-width: 765.9px) {
+    width: 360px;
+  }
+`;

--- a/src/views/ReviewPage/index.tsx
+++ b/src/views/ReviewPage/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './ReviewPage';


### PR DESCRIPTION
## Summary
- 헤더에 활동후기 탭을 추가합니다.
- 해당 탭을 클릭하면 우피 페이지로 이동합니다.
- PC 뷰와, 모바일 뷰에서의 로직이 동일하여 커스텀 훅을 빼내어 동작시킵니다.
- 리뷰 페이지 컴포넌트는 ... 작업을 헷갈려서 만들어두었어요 .. 하하 삭제해도 무방합니다.

## Screenshot

![image](https://user-images.githubusercontent.com/47105088/223342704-ba02180a-35df-41ee-a95b-7b49ee84af5d.png)
![image](https://user-images.githubusercontent.com/47105088/223342755-f392dc35-757a-4e0e-af06-bf64fa3fb3ad.png)


## Comment
