### PR TITLE
헤더 메뉴 탭 로직 수정

### DIFF
--- a/src/components/Header/Desktop/DesktopHeader.tsx
+++ b/src/components/Header/Desktop/DesktopHeader.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import Link from 'next/link';
 import logoIcon from '@src/assets/sopt/logo.png';
 import useHeader from '@src/hooks/useHeader';
-import { MenuTapList, checkIsAnchorMenu } from '../types';
+import { MenuTapList, MenuTapType } from '../types';
 
 function DesktopHeader({ menuTapList }: { menuTapList: MenuTapList }) {
   const { handleClickLogo, handleIsSelected } = useHeader();
@@ -14,20 +14,24 @@ function DesktopHeader({ menuTapList }: { menuTapList: MenuTapList }) {
       </CenterAligner>
       <MenuTitlesWrapper>
         {menuTapList.map((menuTap) => {
-          if (checkIsAnchorMenu(menuTap)) {
-            return (
-              <MenuTitle key={menuTap.title}>
-                <MenuTitleAnchor href={menuTap.anchor} target="_blank" rel="noreferrer">
-                  {menuTap.title}
-                </MenuTitleAnchor>
-              </MenuTitle>
-            );
+          switch (menuTap.type) {
+            case MenuTapType.Anchor:
+              return (
+                <MenuTitle key={menuTap.title}>
+                  <MenuTitleAnchor href={menuTap.anchor} target="_blank" rel="noreferrer">
+                    {menuTap.title}
+                  </MenuTitleAnchor>
+                </MenuTitle>
+              );
+            case MenuTapType.Router:
+              return (
+                <Link key={menuTap.title} href={menuTap.route}>
+                  <MenuTitle isSelected={handleIsSelected(menuTap.route)}>
+                    {menuTap.title}
+                  </MenuTitle>
+                </Link>
+              );
           }
-          return (
-            <Link key={menuTap.title} href={menuTap.route}>
-              <MenuTitle isSelected={handleIsSelected(menuTap.route)}>{menuTap.title}</MenuTitle>
-            </Link>
-          );
         })}
       </MenuTitlesWrapper>
     </Wrapper>

--- a/src/components/Header/Desktop/DesktopHeader.tsx
+++ b/src/components/Header/Desktop/DesktopHeader.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import Link from 'next/link';
 import logoIcon from '@src/assets/sopt/logo.png';
 import useHeader from '@src/hooks/useHeader';
 import { MenuList, checkIsAnchorMenu } from '../Header';
@@ -15,19 +16,17 @@ function DesktopHeader({ menuList }: { menuList: MenuList }) {
         {menuList.map((menuTap) => {
           if (checkIsAnchorMenu(menuTap)) {
             return (
-              <MenuTitle key={menuTap.title} href={menuTap.anchor} target="_blank">
-                {menuTap.title}
+              <MenuTitle key={menuTap.title}>
+                <MenuTitleAnchor href={menuTap.anchor} target="_blank" rel="noreferrer">
+                  {menuTap.title}
+                </MenuTitleAnchor>
               </MenuTitle>
             );
           }
           return (
-            <MenuTitle
-              key={menuTap.title}
-              href={menuTap.route}
-              isSelected={handleIsSelected(menuTap.route)}
-            >
-              {menuTap.title}
-            </MenuTitle>
+            <Link key={menuTap.title} href={menuTap.route}>
+              <MenuTitle isSelected={handleIsSelected(menuTap.route)}>{menuTap.title}</MenuTitle>
+            </Link>
           );
         })}
       </MenuTitlesWrapper>
@@ -79,7 +78,14 @@ export const MenuTitlesWrapper = styled.div`
   align-items: center;
 `;
 
-export const MenuTitle = styled.a<MenuTitleProps>`
+export const MenuTitleAnchor = styled.a`
+  display: block;
+
+  color: inherit;
+  text-decoration: none;
+`;
+
+export const MenuTitle = styled.div<MenuTitleProps>`
   font-family: 'SUIT';
   font-size: 18px;
   line-height: 36px;

--- a/src/components/Header/Desktop/DesktopHeader.tsx
+++ b/src/components/Header/Desktop/DesktopHeader.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import Link from 'next/link';
 import logoIcon from '@src/assets/sopt/logo.png';
 import useHeader from '@src/hooks/useHeader';
-import { MenuList, checkIsAnchorMenu } from '../Header';
+import { MenuList, checkIsAnchorMenu } from '../types';
 
 function DesktopHeader({ menuList }: { menuList: MenuList }) {
   const { handleClickLogo, handleIsSelected } = useHeader();

--- a/src/components/Header/Desktop/DesktopHeader.tsx
+++ b/src/components/Header/Desktop/DesktopHeader.tsx
@@ -1,9 +1,10 @@
 import styled from '@emotion/styled';
 import logoIcon from '@src/assets/sopt/logo.png';
 import useHeader from '@src/hooks/useHeader';
+import { MenuList, checkIsAnchorMenu } from '../Header';
 
-function DesktopHeader({ menuList }: { menuList: { id: string; title: string }[] }) {
-  const { handleClickLogo, handleClickTap, handleIsSelected } = useHeader();
+function DesktopHeader({ menuList }: { menuList: MenuList }) {
+  const { handleClickLogo, handleIsSelected } = useHeader();
 
   return (
     <Wrapper>
@@ -11,11 +12,24 @@ function DesktopHeader({ menuList }: { menuList: { id: string; title: string }[]
         <Logo src={logoIcon.src} onClick={handleClickLogo} />
       </CenterAligner>
       <MenuTitlesWrapper>
-        {menuList.map(({ id, title }) => (
-          <MenuTitle key={id} id={id} isSelected={handleIsSelected(id)} onClick={handleClickTap}>
-            {title}
-          </MenuTitle>
-        ))}
+        {menuList.map((menuTap) => {
+          if (checkIsAnchorMenu(menuTap)) {
+            return (
+              <MenuTitle key={menuTap.title} href={menuTap.anchor} target="_blank">
+                {menuTap.title}
+              </MenuTitle>
+            );
+          }
+          return (
+            <MenuTitle
+              key={menuTap.title}
+              href={menuTap.route}
+              isSelected={handleIsSelected(menuTap.route)}
+            >
+              {menuTap.title}
+            </MenuTitle>
+          );
+        })}
       </MenuTitlesWrapper>
     </Wrapper>
   );
@@ -26,7 +40,7 @@ interface StyleProps {
 }
 
 interface MenuTitleProps {
-  isSelected: boolean;
+  isSelected?: boolean;
 }
 
 export const Wrapper = styled.div`

--- a/src/components/Header/Desktop/DesktopHeader.tsx
+++ b/src/components/Header/Desktop/DesktopHeader.tsx
@@ -14,22 +14,20 @@ function DesktopHeader() {
         <Logo src={logoIcon.src} onClick={handleClickLogo} />
       </CenterAligner>
       <MenuTitlesWrapper>
-        {menuTapList.map((menuTap) => {
-          switch (menuTap.type) {
+        {menuTapList.map(({ type, title, href }) => {
+          switch (type) {
             case MenuTapType.Anchor:
               return (
-                <MenuTitle key={menuTap.title}>
-                  <MenuTitleAnchor href={menuTap.anchor} target="_blank" rel="noreferrer">
-                    {menuTap.title}
+                <MenuTitle key={title}>
+                  <MenuTitleAnchor href={href} target="_blank" rel="noreferrer">
+                    {title}
                   </MenuTitleAnchor>
                 </MenuTitle>
               );
             case MenuTapType.Router:
               return (
-                <Link key={menuTap.title} href={menuTap.route}>
-                  <MenuTitle isSelected={handleIsSelected(menuTap.route)}>
-                    {menuTap.title}
-                  </MenuTitle>
+                <Link key={title} href={href}>
+                  <MenuTitle isSelected={handleIsSelected(href)}>{title}</MenuTitle>
                 </Link>
               );
           }

--- a/src/components/Header/Desktop/DesktopHeader.tsx
+++ b/src/components/Header/Desktop/DesktopHeader.tsx
@@ -2,9 +2,10 @@ import styled from '@emotion/styled';
 import Link from 'next/link';
 import logoIcon from '@src/assets/sopt/logo.png';
 import useHeader from '@src/hooks/useHeader';
-import { MenuTapList, MenuTapType } from '../types';
+import { menuTapList } from '../menuTapList';
+import { MenuTapType } from '../types';
 
-function DesktopHeader({ menuTapList }: { menuTapList: MenuTapList }) {
+function DesktopHeader() {
   const { handleClickLogo, handleIsSelected } = useHeader();
 
   return (

--- a/src/components/Header/Desktop/DesktopHeader.tsx
+++ b/src/components/Header/Desktop/DesktopHeader.tsx
@@ -2,9 +2,9 @@ import styled from '@emotion/styled';
 import Link from 'next/link';
 import logoIcon from '@src/assets/sopt/logo.png';
 import useHeader from '@src/hooks/useHeader';
-import { MenuList, checkIsAnchorMenu } from '../types';
+import { MenuTapList, checkIsAnchorMenu } from '../types';
 
-function DesktopHeader({ menuList }: { menuList: MenuList }) {
+function DesktopHeader({ menuTapList }: { menuTapList: MenuTapList }) {
   const { handleClickLogo, handleIsSelected } = useHeader();
 
   return (
@@ -13,7 +13,7 @@ function DesktopHeader({ menuList }: { menuList: MenuList }) {
         <Logo src={logoIcon.src} onClick={handleClickLogo} />
       </CenterAligner>
       <MenuTitlesWrapper>
-        {menuList.map((menuTap) => {
+        {menuTapList.map((menuTap) => {
           if (checkIsAnchorMenu(menuTap)) {
             return (
               <MenuTitle key={menuTap.title}>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -2,13 +2,26 @@ import { useIsDesktop, useIsMobile, useIsTablet } from '@src/hooks/useDevice';
 import DesktopHeader from './Desktop/DesktopHeader';
 import MobileHeader from './Mobile/MobileHeader';
 import styles from './header.module.scss';
-import { MenuTapList } from './types';
+import { MenuTapList, MenuTapType } from './types';
 
 const menuTapList: MenuTapList = [
-  { title: '프로젝트', route: '/project' },
-  { title: '활동후기', anchor: 'https://sopt-official-review.oopy.io/' },
-  { title: '문의하기', route: '/FAQ' },
   {
+    type: MenuTapType.Router,
+    title: '프로젝트',
+    route: '/project',
+  },
+  {
+    type: MenuTapType.Anchor,
+    title: '활동후기',
+    anchor: 'https://sopt-official-review.oopy.io/',
+  },
+  {
+    type: MenuTapType.Router,
+    title: '문의하기',
+    route: '/FAQ',
+  },
+  {
+    type: MenuTapType.Anchor,
     title: '리크루팅',
     anchor: 'https://sopt-recruiting.web.app/recruiting/apply/yb',
   },

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -2,14 +2,7 @@ import { useIsDesktop, useIsMobile, useIsTablet } from '@src/hooks/useDevice';
 import DesktopHeader from './Desktop/DesktopHeader';
 import MobileHeader from './Mobile/MobileHeader';
 import styles from './header.module.scss';
-
-type RoutingMenu = { title: string; route: string };
-type AnchorMenu = { title: string; anchor: string };
-export type MenuList = Array<RoutingMenu | AnchorMenu>;
-export function checkIsAnchorMenu(menuTap: RoutingMenu | AnchorMenu): menuTap is AnchorMenu {
-  if ('anchor' in menuTap) return true;
-  return false;
-}
+import { MenuList } from './types';
 
 const menuList: MenuList = [
   { title: '프로젝트', route: '/project' },

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -2,9 +2,9 @@ import { useIsDesktop, useIsMobile, useIsTablet } from '@src/hooks/useDevice';
 import DesktopHeader from './Desktop/DesktopHeader';
 import MobileHeader from './Mobile/MobileHeader';
 import styles from './header.module.scss';
-import { MenuList } from './types';
+import { MenuTapList } from './types';
 
-const menuList: MenuList = [
+const menuTapList: MenuTapList = [
   { title: '프로젝트', route: '/project' },
   { title: '활동후기', anchor: 'https://sopt-official-review.oopy.io/' },
   { title: '문의하기', route: '/FAQ' },
@@ -21,9 +21,9 @@ export function Header() {
 
   return (
     <header className={styles.wrapper}>
-      {isDesktop && <DesktopHeader menuList={menuList} />}
-      {isTablet && <MobileHeader menuList={menuList} />}
-      {isMobile && <MobileHeader menuList={menuList} />}
+      {isDesktop && <DesktopHeader menuTapList={menuTapList} />}
+      {isTablet && <MobileHeader menuTapList={menuTapList} />}
+      {isMobile && <MobileHeader menuTapList={menuTapList} />}
     </header>
   );
 }

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -11,6 +11,14 @@ export function checkIsAnchorMenu(menuTap: RoutingMenu | AnchorMenu): menuTap is
   return false;
 }
 
+const menuList: MenuList = [
+  { title: '프로젝트', route: '/project' },
+  { title: '활동후기', anchor: 'https://sopt-official-review.oopy.io/' },
+  { title: '문의하기', route: '/FAQ' },
+  {
+    title: '리크루팅',
+    anchor: 'https://sopt-recruiting.web.app/recruiting/apply/yb',
+  },
 ];
 
 export function Header() {

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -2,30 +2,6 @@ import { useIsDesktop, useIsMobile, useIsTablet } from '@src/hooks/useDevice';
 import DesktopHeader from './Desktop/DesktopHeader';
 import MobileHeader from './Mobile/MobileHeader';
 import styles from './header.module.scss';
-import { MenuTapList, MenuTapType } from './types';
-
-const menuTapList: MenuTapList = [
-  {
-    type: MenuTapType.Router,
-    title: '프로젝트',
-    route: '/project',
-  },
-  {
-    type: MenuTapType.Anchor,
-    title: '활동후기',
-    anchor: 'https://sopt-official-review.oopy.io/',
-  },
-  {
-    type: MenuTapType.Router,
-    title: '문의하기',
-    route: '/FAQ',
-  },
-  {
-    type: MenuTapType.Anchor,
-    title: '리크루팅',
-    anchor: 'https://sopt-recruiting.web.app/recruiting/apply/yb',
-  },
-];
 
 export function Header() {
   const isDesktop = useIsDesktop('992px');
@@ -34,9 +10,9 @@ export function Header() {
 
   return (
     <header className={styles.wrapper}>
-      {isDesktop && <DesktopHeader menuTapList={menuTapList} />}
-      {isTablet && <MobileHeader menuTapList={menuTapList} />}
-      {isMobile && <MobileHeader menuTapList={menuTapList} />}
+      {isDesktop && <DesktopHeader />}
+      {isTablet && <MobileHeader />}
+      {isMobile && <MobileHeader />}
     </header>
   );
 }

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -3,11 +3,14 @@ import DesktopHeader from './Desktop/DesktopHeader';
 import MobileHeader from './Mobile/MobileHeader';
 import styles from './header.module.scss';
 
-const menuList = [
-  { id: '/project', title: '프로젝트' },
-  { id: '/review', title: '활동후기' },
-  { id: '/FAQ', title: '문의하기' },
-  { id: '/recruit', title: '리크루팅' },
+type RoutingMenu = { title: string; route: string };
+type AnchorMenu = { title: string; anchor: string };
+export type MenuList = Array<RoutingMenu | AnchorMenu>;
+export function checkIsAnchorMenu(menuTap: RoutingMenu | AnchorMenu): menuTap is AnchorMenu {
+  if ('anchor' in menuTap) return true;
+  return false;
+}
+
 ];
 
 export function Header() {

--- a/src/components/Header/Mobile/HeaderMenu.style.ts
+++ b/src/components/Header/Mobile/HeaderMenu.style.ts
@@ -9,7 +9,7 @@ interface CloseButtonProps extends RootProps {
 }
 
 interface MenuTitleProps {
-  isSelected: boolean;
+  isSelected?: boolean;
 }
 
 interface RootProps {

--- a/src/components/Header/Mobile/HeaderMenu.style.ts
+++ b/src/components/Header/Mobile/HeaderMenu.style.ts
@@ -124,7 +124,14 @@ export const MenuTitlesWrap = styled.div`
   padding-bottom: 30px;
 `;
 
-export const MenuTitle = styled.a<MenuTitleProps>`
+export const MenuTitleAnchor = styled.a`
+  display: block;
+
+  color: inherit;
+  text-decoration: none;
+`;
+
+export const MenuTitle = styled.div<MenuTitleProps>`
   font-family: 'SUIT';
   font-size: 16px;
   font-weight: 500;
@@ -139,6 +146,7 @@ export const MenuTitle = styled.a<MenuTitleProps>`
     padding-right: 40px;
   }
 `;
+
 export const Rules = styled.a`
   cursor: pointer;
   text-decoration-line: underline;

--- a/src/components/Header/Mobile/HeaderMenu.tsx
+++ b/src/components/Header/Mobile/HeaderMenu.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import useHeader from '@src/hooks/useHeader';
-import { MenuList, checkIsAnchorMenu } from '../Header';
+import { MenuList, checkIsAnchorMenu } from '../types';
 import * as S from './HeaderMenu.style';
 
 type MenuType = 'idle' | 'open' | 'close';

--- a/src/components/Header/Mobile/HeaderMenu.tsx
+++ b/src/components/Header/Mobile/HeaderMenu.tsx
@@ -36,22 +36,20 @@ function HeaderMenu({ isMenuShown, handleHeaderToggleButton }: HeaderMenuProps) 
       <S.MenuWrap>
         <S.ContentsWrap>
           <S.MenuTitlesWrap>
-            {menuTapList.map((menuTap) => {
-              switch (menuTap.type) {
+            {menuTapList.map(({ type, title, href }) => {
+              switch (type) {
                 case MenuTapType.Anchor:
                   return (
-                    <S.MenuTitle key={menuTap.title}>
-                      <S.MenuTitleAnchor href={menuTap.anchor} target="_blank" rel="noreferrer">
-                        {menuTap.title}
+                    <S.MenuTitle key={title}>
+                      <S.MenuTitleAnchor href={href} target="_blank" rel="noreferrer">
+                        {title}
                       </S.MenuTitleAnchor>
                     </S.MenuTitle>
                   );
                 case MenuTapType.Router:
                   return (
-                    <Link key={menuTap.title} href={menuTap.route}>
-                      <S.MenuTitle isSelected={handleIsSelected(menuTap.route)}>
-                        {menuTap.title}
-                      </S.MenuTitle>
+                    <Link key={title} href={href}>
+                      <S.MenuTitle isSelected={handleIsSelected(href)}>{title}</S.MenuTitle>
                     </Link>
                   );
               }

--- a/src/components/Header/Mobile/HeaderMenu.tsx
+++ b/src/components/Header/Mobile/HeaderMenu.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 import { useEffect } from 'react';
 import useHeader from '@src/hooks/useHeader';
-import { MenuList, checkIsAnchorMenu } from '../types';
+import { MenuTapList, checkIsAnchorMenu } from '../types';
 import * as S from './HeaderMenu.style';
 
 type MenuType = 'idle' | 'open' | 'close';
@@ -23,12 +23,12 @@ function useNoScroll(isMenuShown: MenuType) {
 }
 
 interface HeaderMenuProps {
-  menuList: MenuList;
+  menuTapList: MenuTapList;
   isMenuShown: MenuType;
   handleHeaderToggleButton: () => void;
 }
 
-function HeaderMenu({ menuList, isMenuShown, handleHeaderToggleButton }: HeaderMenuProps) {
+function HeaderMenu({ menuTapList, isMenuShown, handleHeaderToggleButton }: HeaderMenuProps) {
   useNoScroll(isMenuShown);
 
   const { handleIsSelected } = useHeader();
@@ -38,7 +38,7 @@ function HeaderMenu({ menuList, isMenuShown, handleHeaderToggleButton }: HeaderM
       <S.MenuWrap>
         <S.ContentsWrap>
           <S.MenuTitlesWrap>
-            {menuList.map((menuTap) => {
+            {menuTapList.map((menuTap) => {
               if (checkIsAnchorMenu(menuTap)) {
                 return (
                   <S.MenuTitle key={menuTap.title}>

--- a/src/components/Header/Mobile/HeaderMenu.tsx
+++ b/src/components/Header/Mobile/HeaderMenu.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 import { useEffect } from 'react';
 import useHeader from '@src/hooks/useHeader';
-import { MenuTapList, checkIsAnchorMenu } from '../types';
+import { MenuTapList, MenuTapType } from '../types';
 import * as S from './HeaderMenu.style';
 
 type MenuType = 'idle' | 'open' | 'close';
@@ -39,22 +39,24 @@ function HeaderMenu({ menuTapList, isMenuShown, handleHeaderToggleButton }: Head
         <S.ContentsWrap>
           <S.MenuTitlesWrap>
             {menuTapList.map((menuTap) => {
-              if (checkIsAnchorMenu(menuTap)) {
-                return (
-                  <S.MenuTitle key={menuTap.title}>
-                    <S.MenuTitleAnchor href={menuTap.anchor} target="_blank" rel="noreferrer">
-                      {menuTap.title}
-                    </S.MenuTitleAnchor>
-                  </S.MenuTitle>
-                );
+              switch (menuTap.type) {
+                case MenuTapType.Anchor:
+                  return (
+                    <S.MenuTitle key={menuTap.title}>
+                      <S.MenuTitleAnchor href={menuTap.anchor} target="_blank" rel="noreferrer">
+                        {menuTap.title}
+                      </S.MenuTitleAnchor>
+                    </S.MenuTitle>
+                  );
+                case MenuTapType.Router:
+                  return (
+                    <Link key={menuTap.title} href={menuTap.route}>
+                      <S.MenuTitle isSelected={handleIsSelected(menuTap.route)}>
+                        {menuTap.title}
+                      </S.MenuTitle>
+                    </Link>
+                  );
               }
-              return (
-                <Link key={menuTap.title} href={menuTap.route}>
-                  <S.MenuTitle isSelected={handleIsSelected(menuTap.route)}>
-                    {menuTap.title}
-                  </S.MenuTitle>
-                </Link>
-              );
             })}
             <S.Background onClick={() => handleHeaderToggleButton()} />
           </S.MenuTitlesWrap>

--- a/src/components/Header/Mobile/HeaderMenu.tsx
+++ b/src/components/Header/Mobile/HeaderMenu.tsx
@@ -1,12 +1,10 @@
 import Link from 'next/link';
 import { useEffect } from 'react';
 import useHeader from '@src/hooks/useHeader';
-import { MenuTapList, MenuTapType } from '../types';
+import { MenuState, MenuTapType } from '../types';
 import * as S from './HeaderMenu.style';
 
-type MenuType = 'idle' | 'open' | 'close';
-
-function useNoScroll(isMenuShown: MenuType) {
+function useNoScroll(isMenuShown: MenuState) {
   useEffect(() => {
     if (isMenuShown === 'open') {
       document.body.style.overflow = 'hidden';
@@ -23,8 +21,7 @@ function useNoScroll(isMenuShown: MenuType) {
 }
 
 interface HeaderMenuProps {
-  menuTapList: MenuTapList;
-  isMenuShown: MenuType;
+  isMenuShown: MenuState;
   handleHeaderToggleButton: () => void;
 }
 

--- a/src/components/Header/Mobile/HeaderMenu.tsx
+++ b/src/components/Header/Mobile/HeaderMenu.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { useEffect } from 'react';
 import useHeader from '@src/hooks/useHeader';
+import { menuTapList } from '../menuTapList';
 import { MenuState, MenuTapType } from '../types';
 import * as S from './HeaderMenu.style';
 
@@ -25,7 +26,7 @@ interface HeaderMenuProps {
   handleHeaderToggleButton: () => void;
 }
 
-function HeaderMenu({ menuTapList, isMenuShown, handleHeaderToggleButton }: HeaderMenuProps) {
+function HeaderMenu({ isMenuShown, handleHeaderToggleButton }: HeaderMenuProps) {
   useNoScroll(isMenuShown);
 
   const { handleIsSelected } = useHeader();

--- a/src/components/Header/Mobile/HeaderMenu.tsx
+++ b/src/components/Header/Mobile/HeaderMenu.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import React, { useEffect } from 'react';
 import useHeader from '@src/hooks/useHeader';
 import { MenuList, checkIsAnchorMenu } from '../Header';
@@ -40,19 +41,19 @@ function HeaderMenu({ menuList, isMenuShown, handleHeaderToggleButton }: HeaderM
             {menuList.map((menuTap) => {
               if (checkIsAnchorMenu(menuTap)) {
                 return (
-                  <S.MenuTitle key={menuTap.title} href={menuTap.anchor} target="_blank">
-                    {menuTap.title}
+                  <S.MenuTitle key={menuTap.title}>
+                    <S.MenuTitleAnchor href={menuTap.anchor} target="_blank" rel="noreferrer">
+                      {menuTap.title}
+                    </S.MenuTitleAnchor>
                   </S.MenuTitle>
                 );
               }
               return (
-                <S.MenuTitle
-                  key={menuTap.title}
-                  href={menuTap.route}
-                  isSelected={handleIsSelected(menuTap.route)}
-                >
-                  {menuTap.title}
-                </S.MenuTitle>
+                <Link key={menuTap.title} href={menuTap.route}>
+                  <S.MenuTitle isSelected={handleIsSelected(menuTap.route)}>
+                    {menuTap.title}
+                  </S.MenuTitle>
+                </Link>
               );
             })}
             <S.Background onClick={() => handleHeaderToggleButton()} />

--- a/src/components/Header/Mobile/HeaderMenu.tsx
+++ b/src/components/Header/Mobile/HeaderMenu.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
 import useHeader from '@src/hooks/useHeader';
+import { MenuList, checkIsAnchorMenu } from '../Header';
 import * as S from './HeaderMenu.style';
 
 type MenuType = 'idle' | 'open' | 'close';
@@ -21,7 +22,7 @@ function useNoScroll(isMenuShown: MenuType) {
 }
 
 interface HeaderMenuProps {
-  menuList: { id: string; title: string }[];
+  menuList: MenuList;
   isMenuShown: MenuType;
   handleHeaderToggleButton: () => void;
 }
@@ -29,23 +30,31 @@ interface HeaderMenuProps {
 function HeaderMenu({ menuList, isMenuShown, handleHeaderToggleButton }: HeaderMenuProps) {
   useNoScroll(isMenuShown);
 
-  const { handleClickTap, handleIsSelected } = useHeader();
+  const { handleIsSelected } = useHeader();
 
   return (
     <S.Root isMenuShown={isMenuShown}>
       <S.MenuWrap>
         <S.ContentsWrap>
           <S.MenuTitlesWrap>
-            {menuList.map(({ id, title }) => (
-              <S.MenuTitle
-                key={id}
-                id={id}
-                isSelected={handleIsSelected(id)}
-                onClick={handleClickTap}
-              >
-                {title}
-              </S.MenuTitle>
-            ))}
+            {menuList.map((menuTap) => {
+              if (checkIsAnchorMenu(menuTap)) {
+                return (
+                  <S.MenuTitle key={menuTap.title} href={menuTap.anchor} target="_blank">
+                    {menuTap.title}
+                  </S.MenuTitle>
+                );
+              }
+              return (
+                <S.MenuTitle
+                  key={menuTap.title}
+                  href={menuTap.route}
+                  isSelected={handleIsSelected(menuTap.route)}
+                >
+                  {menuTap.title}
+                </S.MenuTitle>
+              );
+            })}
             <S.Background onClick={() => handleHeaderToggleButton()} />
           </S.MenuTitlesWrap>
         </S.ContentsWrap>

--- a/src/components/Header/Mobile/MobileHeader.tsx
+++ b/src/components/Header/Mobile/MobileHeader.tsx
@@ -6,11 +6,12 @@ import menuBar from '@src/assets/icons/menuBar.svg';
 import xButton from '@src/assets/icons/xButton.png';
 import logoIcon from '@src/assets/sopt/logo.png';
 import { Condition } from '@src/lib';
+import { MenuList } from '../Header';
 import HeaderMenu from './HeaderMenu';
 
 export type MenuType = 'idle' | 'open' | 'close';
 
-function MobileHeader({ menuList }: { menuList: { id: string; title: string }[] }) {
+function MobileHeader({ menuList }: { menuList: MenuList }) {
   const router = useRouter();
   const [isMenuShown, setIsMenuShown] = useState<MenuType>('idle');
 

--- a/src/components/Header/Mobile/MobileHeader.tsx
+++ b/src/components/Header/Mobile/MobileHeader.tsx
@@ -6,14 +6,14 @@ import menuBar from '@src/assets/icons/menuBar.svg';
 import xButton from '@src/assets/icons/xButton.png';
 import logoIcon from '@src/assets/sopt/logo.png';
 import { Condition } from '@src/lib';
-import { MenuTapList } from '../types';
+import { MenuState } from '../types';
 import HeaderMenu from './HeaderMenu';
 
 export type MenuType = 'idle' | 'open' | 'close';
 
 function MobileHeader({ menuTapList }: { menuTapList: MenuTapList }) {
   const router = useRouter();
-  const [isMenuShown, setIsMenuShown] = useState<MenuType>('idle');
+  const [isMenuShown, setIsMenuShown] = useState<MenuState>('idle');
 
   const handleHeaderToggleButton = () => {
     setIsMenuShown((prev) => (prev === 'open' ? 'close' : 'open'));

--- a/src/components/Header/Mobile/MobileHeader.tsx
+++ b/src/components/Header/Mobile/MobileHeader.tsx
@@ -9,9 +9,7 @@ import { Condition } from '@src/lib';
 import { MenuState } from '../types';
 import HeaderMenu from './HeaderMenu';
 
-export type MenuType = 'idle' | 'open' | 'close';
-
-function MobileHeader({ menuTapList }: { menuTapList: MenuTapList }) {
+function MobileHeader() {
   const router = useRouter();
   const [isMenuShown, setIsMenuShown] = useState<MenuState>('idle');
 
@@ -32,11 +30,7 @@ function MobileHeader({ menuTapList }: { menuTapList: MenuTapList }) {
         </ToggleButton>
       </StyledHeader>
       <Condition statement={isMenuShown === 'open'}>
-        <HeaderMenu
-          menuTapList={menuTapList}
-          isMenuShown={isMenuShown}
-          handleHeaderToggleButton={handleHeaderToggleButton}
-        />
+        <HeaderMenu isMenuShown={isMenuShown} handleHeaderToggleButton={handleHeaderToggleButton} />
       </Condition>
     </>
   );

--- a/src/components/Header/Mobile/MobileHeader.tsx
+++ b/src/components/Header/Mobile/MobileHeader.tsx
@@ -6,7 +6,7 @@ import menuBar from '@src/assets/icons/menuBar.svg';
 import xButton from '@src/assets/icons/xButton.png';
 import logoIcon from '@src/assets/sopt/logo.png';
 import { Condition } from '@src/lib';
-import { MenuList } from '../Header';
+import { MenuList } from '../types';
 import HeaderMenu from './HeaderMenu';
 
 export type MenuType = 'idle' | 'open' | 'close';

--- a/src/components/Header/Mobile/MobileHeader.tsx
+++ b/src/components/Header/Mobile/MobileHeader.tsx
@@ -6,12 +6,12 @@ import menuBar from '@src/assets/icons/menuBar.svg';
 import xButton from '@src/assets/icons/xButton.png';
 import logoIcon from '@src/assets/sopt/logo.png';
 import { Condition } from '@src/lib';
-import { MenuList } from '../types';
+import { MenuTapList } from '../types';
 import HeaderMenu from './HeaderMenu';
 
 export type MenuType = 'idle' | 'open' | 'close';
 
-function MobileHeader({ menuList }: { menuList: MenuList }) {
+function MobileHeader({ menuTapList }: { menuTapList: MenuTapList }) {
   const router = useRouter();
   const [isMenuShown, setIsMenuShown] = useState<MenuType>('idle');
 
@@ -33,7 +33,7 @@ function MobileHeader({ menuList }: { menuList: MenuList }) {
       </StyledHeader>
       <Condition statement={isMenuShown === 'open'}>
         <HeaderMenu
-          menuList={menuList}
+          menuTapList={menuTapList}
           isMenuShown={isMenuShown}
           handleHeaderToggleButton={handleHeaderToggleButton}
         />

--- a/src/components/Header/menuTapList.ts
+++ b/src/components/Header/menuTapList.ts
@@ -1,0 +1,24 @@
+import { MenuTapList, MenuTapType } from './types';
+
+export const menuTapList: MenuTapList = [
+  {
+    type: MenuTapType.Router,
+    title: '프로젝트',
+    route: '/project',
+  },
+  {
+    type: MenuTapType.Anchor,
+    title: '활동후기',
+    anchor: 'https://sopt-official-review.oopy.io/',
+  },
+  {
+    type: MenuTapType.Router,
+    title: '문의하기',
+    route: '/FAQ',
+  },
+  {
+    type: MenuTapType.Anchor,
+    title: '리크루팅',
+    anchor: 'https://sopt-recruiting.web.app/recruiting/apply/yb',
+  },
+];

--- a/src/components/Header/menuTapList.ts
+++ b/src/components/Header/menuTapList.ts
@@ -4,21 +4,21 @@ export const menuTapList: MenuTapList = [
   {
     type: MenuTapType.Router,
     title: '프로젝트',
-    route: '/project',
+    href: '/project',
   },
   {
     type: MenuTapType.Anchor,
     title: '활동후기',
-    anchor: 'https://sopt-official-review.oopy.io/',
+    href: 'https://sopt-official-review.oopy.io/',
   },
   {
     type: MenuTapType.Router,
     title: '문의하기',
-    route: '/FAQ',
+    href: '/FAQ',
   },
   {
     type: MenuTapType.Anchor,
     title: '리크루팅',
-    anchor: 'https://sopt-recruiting.web.app/recruiting/apply/yb',
+    href: 'https://sopt-recruiting.web.app/recruiting/apply/yb',
   },
 ];

--- a/src/components/Header/types.ts
+++ b/src/components/Header/types.ts
@@ -1,0 +1,9 @@
+type RoutingMenu = { title: string; route: string };
+type AnchorMenu = { title: string; anchor: string };
+
+export type MenuList = Array<RoutingMenu | AnchorMenu>;
+
+export function checkIsAnchorMenu(menuTap: RoutingMenu | AnchorMenu): menuTap is AnchorMenu {
+  if ('anchor' in menuTap) return true;
+  return false;
+}

--- a/src/components/Header/types.ts
+++ b/src/components/Header/types.ts
@@ -1,3 +1,5 @@
+export type MenuState = 'idle' | 'open' | 'close';
+
 export const enum MenuTapType {
   Router = 'ROUTER',
   Anchor = 'ANCHOR',

--- a/src/components/Header/types.ts
+++ b/src/components/Header/types.ts
@@ -1,9 +1,14 @@
-type RoutingMenu = { title: string; route: string };
-type AnchorMenu = { title: string; anchor: string };
+export const enum MenuTapType {
+  Router = 'ROUTER',
+  Anchor = 'ANCHOR',
+};
 
-export type MenuTapList = Array<RoutingMenu | AnchorMenu>;
-
-export function checkIsAnchorMenu(menuTap: RoutingMenu | AnchorMenu): menuTap is AnchorMenu {
-  if ('anchor' in menuTap) return true;
-  return false;
+interface BaseMenuTap {
+  type: MenuTapType;
+  title: string;
 }
+
+interface RoutingMenuTap extends BaseMenuTap { type: MenuTapType.Router; route: string };
+interface AnchorMenuTap extends BaseMenuTap { type: MenuTapType.Anchor; anchor: string };
+
+export type MenuTapList = Array<RoutingMenuTap | AnchorMenuTap>;

--- a/src/components/Header/types.ts
+++ b/src/components/Header/types.ts
@@ -8,9 +8,7 @@ export const enum MenuTapType {
 interface BaseMenuTap {
   type: MenuTapType;
   title: string;
+  href: string;
 }
 
-interface RoutingMenuTap extends BaseMenuTap { type: MenuTapType.Router; route: string };
-interface AnchorMenuTap extends BaseMenuTap { type: MenuTapType.Anchor; anchor: string };
-
-export type MenuTapList = Array<RoutingMenuTap | AnchorMenuTap>;
+export type MenuTapList = BaseMenuTap[];

--- a/src/components/Header/types.ts
+++ b/src/components/Header/types.ts
@@ -1,7 +1,7 @@
 type RoutingMenu = { title: string; route: string };
 type AnchorMenu = { title: string; anchor: string };
 
-export type MenuList = Array<RoutingMenu | AnchorMenu>;
+export type MenuTapList = Array<RoutingMenu | AnchorMenu>;
 
 export function checkIsAnchorMenu(menuTap: RoutingMenu | AnchorMenu): menuTap is AnchorMenu {
   if ('anchor' in menuTap) return true;

--- a/src/hooks/useHeader.ts
+++ b/src/hooks/useHeader.ts
@@ -5,25 +5,12 @@ function useHeader() {
 
   const handleClickLogo = () => router.push('/');
 
-  const handleClickTap = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
-    const currentMenu = e.currentTarget.id;
-
-    if (currentMenu === '/review') {
-      return window.open('https://sopt-official-review.oopy.io/');
-    }
-    if (currentMenu === '/recruit') {
-      return window.open('https://sopt-recruiting.web.app/recruiting/apply/yb');
-    }
-
-    router.push(currentMenu);
-  };
-
   const handleIsSelected = (path: string) => {
     if (path.includes('project') && router.pathname.includes('project')) return true;
     return router.pathname === path;
   };
 
-  return { handleClickLogo, handleClickTap, handleIsSelected };
+  return { handleClickLogo, handleIsSelected };
 
 }
 

--- a/src/hooks/useHeader.ts
+++ b/src/hooks/useHeader.ts
@@ -6,12 +6,10 @@ function useHeader() {
   const handleClickLogo = () => router.push('/');
 
   const handleIsSelected = (path: string) => {
-    if (path.includes('project') && router.pathname.includes('project')) return true;
-    return router.pathname === path;
+    return router.pathname.startsWith(path);
   };
 
   return { handleClickLogo, handleIsSelected };
-
 }
 
 export default useHeader;

--- a/src/hooks/useNoScroll.ts
+++ b/src/hooks/useNoScroll.ts
@@ -1,7 +1,7 @@
+import { MenuState } from '@src/components/Header/types';
 import { useEffect } from 'react';
-import { MenuType } from '@src/components/Header/Mobile/MobileHeader';
 
-export default function useNoScroll(isMenuShown: MenuType) {
+export default function useNoScroll(isMenuShown: MenuState) {
   useEffect(() => {
     if (isMenuShown === 'open') {
       document.body.style.overflow = 'hidden';


### PR DESCRIPTION
## Summary
1. menuList의 프로퍼티를 바꿨어요. id에 라우팅 정보가 들어가있는게 어색했기 때문에요!
    1. 타이핑을 선언하였어요. (id를 임의로 추가하는 게 좋을까요-) 그리고 해당 파일을 `components/Header/types.ts` 에 위치시켰습니다!
        ```typescript
        type RoutingMenu = { title: string; route: string };
        type AnchorMenu = { title: string; anchor: string };
        export type MenuList = Array<RoutingMenu | AnchorMenu>;
        ```
    2. 라우팅 정보가 있는 메뉴들은 `Link` 태그로 치환하였어요. 하지만, 새 탭으로 링크를 보내는 anchor 로직같은 경우에는, `Link` 태그를 쓰는 의미가 없다고 하더군요. 그래서 a 태그를 그대로 사용하였습니다.

2. handleIsSelected 라우팅 기반으로 바꾸기
    라우팅 정보를 기반으로 판단하도록 로직을 수정하였습니다!
    ```typescript
    const handleIsSelected = (path: string) => {
      return router.pathname.startsWith(path);
    };
    ```

## Screenshot
![image](https://user-images.githubusercontent.com/47105088/223709213-a07b2562-35c1-487a-b426-3cedc0b644cb.png)
![image](https://user-images.githubusercontent.com/47105088/223709151-c37686a6-9761-44eb-933b-6246c2884aa6.png)

## Comment
피드백 적극 수용합니다 !!!~