### PR TITLE
refactor: give base url based on node environment

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,8 +1,9 @@
+import { BASE_URL, DEFAULT_TIMEOUT } from '@src/utils/const/client';
 import axios from 'axios';
 
 const client = axios.create({
-  baseURL: 'https://api.sopt.org',
-  timeout: 3000,
+  baseURL: BASE_URL,
+  timeout: DEFAULT_TIMEOUT,
 });
 
 export const getMainLogo = async () => {

--- a/src/lib/project.ts
+++ b/src/lib/project.ts
@@ -1,9 +1,10 @@
+import { BASE_URL, DEFAULT_TIMEOUT } from '@src/utils/const/client';
 import { ProjectCategoryType } from '@src/views/ProjectPage/lib/constants';
 import axios from 'axios';
 
 const client = axios.create({
-  baseURL: 'https://api.sopt.org',
-  timeout: 3000,
+  baseURL: BASE_URL,
+  timeout: DEFAULT_TIMEOUT,
 });
 
 export const getProjectDetail = async (projectId: number) => {

--- a/src/utils/const/client.ts
+++ b/src/utils/const/client.ts
@@ -1,0 +1,6 @@
+const BASE_DEV_URL = 'https://api-dev.sopt.org';
+const BASE_PROD_URL = 'https://api.sopt.org';
+
+export const BASE_URL = process.env.NODE_ENV === 'development' ? BASE_DEV_URL : BASE_PROD_URL;
+
+export const DEFAULT_TIMEOUT = 3000;


### PR DESCRIPTION
## Summary
서버 도메인을 BASE_URL로 제공했습니다! 

하는 김에 타임아웃도 매직넘버를 빼고 상수로 만들었습니다!

언젠가 저 클라이언트 자체를 어디선가 export하는 것도 괜찮을 것 같습니다

## Comment
현재 https://api-dev.sopt.org/projects 로 요청을 보내면 500이 터져서, 이것을 머지하면 프로젝트 탭에서 오류가 발생합니다! 원인을 함 파악해 보아야 할 것 같습니다