### PR TITLE
활동후기 메인 뷰 추가

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -9,6 +9,7 @@ const nextConfig = {
       'sopt-makers.s3.ap-northeast-2.amazonaws.com',
       's3.ap-northeast-2.amazonaws.com',
       'user-images.githubusercontent.com',
+      'static.wikia.nocookie.net',
     ],
   },
   webpack: (config) => {

--- a/src/components/Header/menuTapList.ts
+++ b/src/components/Header/menuTapList.ts
@@ -7,9 +7,9 @@ export const menuTapList: MenuTapList = [
     href: '/project',
   },
   {
-    type: MenuTapType.Anchor,
+    type: MenuTapType.Router,
     title: '활동후기',
-    href: 'https://sopt-official-review.oopy.io/',
+    href: '/review',
   },
   {
     type: MenuTapType.Router,

--- a/src/hooks/useFetchBase/index.ts
+++ b/src/hooks/useFetchBase/index.ts
@@ -1,0 +1,37 @@
+import { to } from 'await-to-js';
+import { useEffect, useReducer } from 'react';
+import { reducer } from './reducer';
+import type { Action, State } from './types';
+
+function useFetchBase<T>(willFetch: () => Promise<T[]>): State<T> {
+  const [state, dispatch] = useReducer<React.Reducer<State<T>, Action<T>>>(reducer, {
+    _TAG: 'IDLE',
+  });
+
+  useEffect(() => {
+    const fetchProjectList = async () => {
+      dispatch({
+        _TAG: 'FETCH',
+      });
+
+      const [error, response] = await to(willFetch());
+
+      if (error) {
+        return dispatch({
+          _TAG: 'FAILED',
+          error,
+        });
+      }
+
+      if (response) {
+        return dispatch({ _TAG: 'SUCCESS', data: response });
+      }
+    };
+
+    fetchProjectList();
+  }, [willFetch]);
+
+  return state;
+}
+
+export default useFetchBase;

--- a/src/hooks/useFetchBase/reducer.ts
+++ b/src/hooks/useFetchBase/reducer.ts
@@ -1,9 +1,6 @@
-import type { Action, ProjectType, State } from '../types';
+import type { Action, State } from './types';
 
-export function reducer(
-  prevState: State<ProjectType>,
-  action: Action<ProjectType>,
-): State<ProjectType> {
+export function reducer<T>(prevState: State<T>, action: Action<T>): State<T> {
   switch (prevState._TAG) {
     case 'IDLE':
       if (action._TAG === 'FETCH') {

--- a/src/hooks/useFetchBase/types.ts
+++ b/src/hooks/useFetchBase/types.ts
@@ -1,0 +1,28 @@
+export type State<T> =
+  | {
+      _TAG: 'IDLE';
+    }
+  | {
+      _TAG: 'LOADING';
+    }
+  | {
+      _TAG: 'ERROR';
+      error: Error;
+    }
+  | {
+      _TAG: 'OK';
+      data: T[];
+    };
+
+export type Action<T> =
+  | {
+      _TAG: 'FETCH';
+    }
+  | {
+      _TAG: 'FAILED';
+      error: Error;
+    }
+  | {
+      _TAG: 'SUCCESS';
+      data: T[];
+    };

--- a/src/lib/project.ts
+++ b/src/lib/project.ts
@@ -1,4 +1,5 @@
 import { ProjectCategoryType } from '@src/views/ProjectPage/lib/constants';
+import { ProjectType } from '@src/views/ProjectPage/types';
 import axios from 'axios';
 
 const client = axios.create({
@@ -12,14 +13,8 @@ export const getProjectDetail = async (projectId: number) => {
   return data;
 };
 
-export const getProjectByCategory = async (category: Omit<ProjectCategoryType, 'ALL'>) => {
-  const { data } = await client.get(`/projects?filter=${category}`);
-
-  return data;
-};
-
-export const getProjectList = async () => {
-  const { data } = await client.get('/projects');
-
+export const getProjectList = async (category?: ProjectCategoryType): Promise<ProjectType[]> => {
+  const queryString = category !== ProjectCategoryType.ALL ? `?filter=${category}` : '';
+  const { data } = await client.get(`/projects${queryString}`);
   return data;
 };

--- a/src/lib/review.ts
+++ b/src/lib/review.ts
@@ -1,0 +1,13 @@
+import { ReviewType, TAB } from '@src/views/ReviewPage/types';
+import axios from 'axios';
+
+const client = axios.create({
+  baseURL: 'https://api-dev.sopt.org',
+  timeout: 3000,
+});
+
+export const getReviews = async (tab: TAB): Promise<ReviewType[]> => {
+  const parameter = tab === TAB.ALL ? '' : `?part=${tab}`;
+  const { data } = await client.get(`/reviews${parameter}`);
+  return data.data;
+};

--- a/src/lib/review.ts
+++ b/src/lib/review.ts
@@ -11,3 +11,8 @@ export const getReviews = async (tab: TAB): Promise<ReviewType[]> => {
   const { data } = await client.get(`/reviews${parameter}`);
   return data.data;
 };
+
+export const getSampleReviews = async (): Promise<ReviewType[]> => {
+  const { data } = await client.get('/reviews/random');
+  return data;
+};

--- a/src/views/MainPage/MainPage.tsx
+++ b/src/views/MainPage/MainPage.tsx
@@ -1,6 +1,7 @@
 import { Footer, Header, Layout, ScrollToTopButton } from '@src/components';
 import {
   ActivityDescription,
+  ActivityReview,
   BannerImage,
   CoporatePartner,
   CorporateLinkedActivities,
@@ -23,6 +24,7 @@ function MainPage() {
             <PartDescription />
             <ActivityDescription />
             <DetailedInformation />
+            <ActivityReview />
             <CoporatePartner />
             <CorporateLinkedActivities />
           </div>

--- a/src/views/MainPage/assets/arrow_right_white.svg
+++ b/src/views/MainPage/assets/arrow_right_white.svg
@@ -1,0 +1,5 @@
+<svg width="current" height="current" viewBox="0 0 31 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="ic_arrow_right_white">
+<path id="Vector 3" d="M12.375 23.75L19.7108 16.4142C20.4918 15.6332 20.4918 14.3668 19.7108 13.5858L12.375 6.25" stroke="#262626" stroke-opacity="0.6" stroke-width="2" stroke-linecap="round"/>
+</g>
+</svg>

--- a/src/views/MainPage/components/ActivityDescription/activity-description.module.scss
+++ b/src/views/MainPage/components/ActivityDescription/activity-description.module.scss
@@ -122,7 +122,7 @@
   }
   @include desktop {
     align-items: center;
-    width: 1100px;
+    width: 1200px;
     height: 308px;
     gap: 30px;
     margin-bottom: 16px;

--- a/src/views/MainPage/components/ActivityReview/ActivityReview.tsx
+++ b/src/views/MainPage/components/ActivityReview/ActivityReview.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { ReactComponent as ArrowLeft } from '@src/views/MainPage/assets/arrow-left-28x28.svg';
 import { ReactComponent as ArrowRight } from '@src/views/MainPage/assets/arrow-right-28x28.svg';
+import { ReactComponent as LinkArrowRight } from '@src/views/MainPage/assets/arrow_right_white.svg';
 import { useHorizontalScroll } from '@src/views/MainPage/lib';
 import styles from './activity-review.module.scss';
 
@@ -17,7 +18,9 @@ export function ActivityReview() {
     <section className={styles.container}>
       <div className={styles.titleWrapper}>
         <h3 className={styles.title}>{'회원들의 후기로\nSOPT 활동을 미리 만나보세요.'}</h3>
-        <Link href="/review">활동후기 더보기</Link>
+        <Link href="/review">
+          <h4 className={styles.moreLink}>활동후기 더보기</h4>
+        </Link>
       </div>
       <div className={styles.contentWrapper}>
         <div
@@ -27,7 +30,32 @@ export function ActivityReview() {
           <ArrowLeft stroke={isLeftScrollable ? 'white' : 'grey'} />
         </div>
         <div className={styles.content} ref={scrollableRef}>
-          content!!!!!!!!!!!!!!!!!!
+          {/* content!!!!!!!!!!!!!!!!!! */}
+          <article className={styles.card} role="presentation">
+            <h4 className={styles.cardTitle}>a</h4>
+
+            <p className={styles.desc}>
+              <div>xzc</div>
+              <LinkArrowRight className={styles.arrow} />
+            </p>
+          </article>
+
+          <article className={styles.card} role="presentation">
+            <h4 className={styles.cardTitle}>zxc</h4>
+            <p className={styles.desc}>
+              <div>xzc</div>
+              <LinkArrowRight className={styles.arrow} />
+            </p>
+          </article>
+
+          <article className={styles.card} role="presentation">
+            <h4 className={styles.cardTitle}>zxc</h4>
+            <p className={styles.desc}>
+              <div>xzc</div>
+              <LinkArrowRight className={styles.arrow} />
+            </p>
+          </article>
+          {/* content!!!!!!!!!!!!!!!!!! */}
         </div>
         <div
           className={styles.arrowWrapper}

--- a/src/views/MainPage/components/ActivityReview/ActivityReview.tsx
+++ b/src/views/MainPage/components/ActivityReview/ActivityReview.tsx
@@ -40,7 +40,8 @@ export function ActivityReview() {
               <h4 className={styles.cardTitle}>{review.title}</h4>
               <p className={styles.desc}>
                 <div>
-                  {parsePartToKorean(review.part)}파트 {review.semester}기 {review.reviewer}
+                  {parsePartToKorean(review.part)} {review.semester}기{'\n'}
+                  <strong className={styles.descName}>{review.reviewer}</strong>
                 </div>
                 <LinkArrowRight className={styles.arrow} />
               </p>

--- a/src/views/MainPage/components/ActivityReview/ActivityReview.tsx
+++ b/src/views/MainPage/components/ActivityReview/ActivityReview.tsx
@@ -4,8 +4,11 @@ import { ReactComponent as ArrowRight } from '@src/views/MainPage/assets/arrow-r
 import { ReactComponent as LinkArrowRight } from '@src/views/MainPage/assets/arrow_right_white.svg';
 import { useHorizontalScroll } from '@src/views/MainPage/lib';
 import styles from './activity-review.module.scss';
+import useFetch from './hooks/useFetch';
+import { parsePartToKorean } from './utils/parsePartToKorean';
 
 export function ActivityReview() {
+  const reviews = useFetch();
   const {
     scrollableRef,
     onClickLeftButton,
@@ -13,6 +16,8 @@ export function ActivityReview() {
     isLeftScrollable,
     isRightScrollable,
   } = useHorizontalScroll(900, 2);
+
+  if (reviews._TAG !== 'OK') return null;
 
   return (
     <section className={styles.container}>
@@ -30,32 +35,17 @@ export function ActivityReview() {
           <ArrowLeft stroke={isLeftScrollable ? 'white' : 'grey'} />
         </div>
         <div className={styles.content} ref={scrollableRef}>
-          {/* content!!!!!!!!!!!!!!!!!! */}
-          <article className={styles.card} role="presentation">
-            <h4 className={styles.cardTitle}>a</h4>
-
-            <p className={styles.desc}>
-              <div>xzc</div>
-              <LinkArrowRight className={styles.arrow} />
-            </p>
-          </article>
-
-          <article className={styles.card} role="presentation">
-            <h4 className={styles.cardTitle}>zxc</h4>
-            <p className={styles.desc}>
-              <div>xzc</div>
-              <LinkArrowRight className={styles.arrow} />
-            </p>
-          </article>
-
-          <article className={styles.card} role="presentation">
-            <h4 className={styles.cardTitle}>zxc</h4>
-            <p className={styles.desc}>
-              <div>xzc</div>
-              <LinkArrowRight className={styles.arrow} />
-            </p>
-          </article>
-          {/* content!!!!!!!!!!!!!!!!!! */}
+          {reviews.data.map((review) => (
+            <article key={review.id} className={styles.card} role="presentation">
+              <h4 className={styles.cardTitle}>{review.title}</h4>
+              <p className={styles.desc}>
+                <div>
+                  {parsePartToKorean(review.part)}파트 {review.semester}기 {review.reviewer}
+                </div>
+                <LinkArrowRight className={styles.arrow} />
+              </p>
+            </article>
+          ))}
         </div>
         <div
           className={styles.arrowWrapper}

--- a/src/views/MainPage/components/ActivityReview/ActivityReview.tsx
+++ b/src/views/MainPage/components/ActivityReview/ActivityReview.tsx
@@ -15,7 +15,7 @@ export function ActivityReview() {
     onClickRightButton,
     isLeftScrollable,
     isRightScrollable,
-  } = useHorizontalScroll(900, 2);
+  } = useHorizontalScroll(1032, 1);
 
   if (reviews._TAG !== 'OK') return null;
 
@@ -40,7 +40,7 @@ export function ActivityReview() {
               <h4 className={styles.cardTitle}>{review.title}</h4>
               <p className={styles.desc}>
                 <div>
-                  {parsePartToKorean(review.part)} {review.semester}기{'\n'}
+                  {parsePartToKorean(review.part)}파트 {review.semester}기{'\n'}
                   <strong className={styles.descName}>{review.reviewer}</strong>
                 </div>
                 <LinkArrowRight className={styles.arrow} />

--- a/src/views/MainPage/components/ActivityReview/ActivityReview.tsx
+++ b/src/views/MainPage/components/ActivityReview/ActivityReview.tsx
@@ -1,0 +1,41 @@
+import Link from 'next/link';
+import { ReactComponent as ArrowLeft } from '@src/views/MainPage/assets/arrow-left-28x28.svg';
+import { ReactComponent as ArrowRight } from '@src/views/MainPage/assets/arrow-right-28x28.svg';
+import { useHorizontalScroll } from '@src/views/MainPage/lib';
+import styles from './activity-review.module.scss';
+
+export function ActivityReview() {
+  const {
+    scrollableRef,
+    onClickLeftButton,
+    onClickRightButton,
+    isLeftScrollable,
+    isRightScrollable,
+  } = useHorizontalScroll(900, 2);
+
+  return (
+    <section className={styles.container}>
+      <div className={styles.titleWrapper}>
+        <h3 className={styles.title}>{'회원들의 후기로\nSOPT 활동을 미리 만나보세요.'}</h3>
+        <Link href="/review">활동후기 더보기</Link>
+      </div>
+      <div className={styles.contentWrapper}>
+        <div
+          className={styles.arrowWrapper}
+          onClick={() => onClickLeftButton(scrollableRef.current)}
+        >
+          <ArrowLeft stroke={isLeftScrollable ? 'white' : 'grey'} />
+        </div>
+        <div className={styles.content} ref={scrollableRef}>
+          content!!!!!!!!!!!!!!!!!!
+        </div>
+        <div
+          className={styles.arrowWrapper}
+          onClick={() => onClickRightButton(scrollableRef.current)}
+        >
+          <ArrowRight stroke={isRightScrollable ? 'white' : 'grey'} />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/views/MainPage/components/ActivityReview/activity-review.module.scss
+++ b/src/views/MainPage/components/ActivityReview/activity-review.module.scss
@@ -74,10 +74,20 @@
 }
 
 .contentWrapper {
-  width: 100%;
   display: flex;
   justify-content: space-between;
   align-items: center;
+  @include mobile {
+    width: 100vw;
+    padding: 0 16px;
+  }
+  @include tablet {
+    width: 100vw;
+    padding: 0 24px;
+  }
+  @include desktop {
+    width: 100%;
+  }
 }
 
 .arrowWrapper {

--- a/src/views/MainPage/components/ActivityReview/activity-review.module.scss
+++ b/src/views/MainPage/components/ActivityReview/activity-review.module.scss
@@ -19,15 +19,26 @@
 }
 
 .titleWrapper {
-  width: 100%;
   display: flex;
-  justify-content: space-between;
+  flex-direction: column;
   align-items: center;
+  @include mobile {
+    gap: 8px;
+  }
+  @include tablet {
+    gap: 24px;
+  }
+  @include desktop {
+    width: 100%;
+    flex-direction: row;
+    justify-content: space-between;
+  }
 }
 
 .title {
   font-weight: 800;
   white-space: pre-wrap;
+  text-align: center;
   @include mobile {
     font-size: 20px;
     line-height: 28px;
@@ -37,9 +48,28 @@
     line-height: 56px;
   }
   @include desktop {
-    width: 100%;
+    text-align: left;
     font-size: 45px;
     line-height: 60px;
+  }
+}
+
+.moreLink {
+  cursor: pointer;
+  font-weight: 400;
+  color: rgba(255, 255, 255, 0.6);
+  text-decoration: underline;
+  @include mobile {
+    font-size: 16px;
+    line-height: 24px;
+  }
+  @include tablet {
+    font-size: 25px;
+    line-height: 24px;
+  }
+  @include desktop {
+    font-size: 25px;
+    line-height: 30px;
   }
 }
 
@@ -70,70 +100,62 @@
 }
 
 .content {
-  display: grid;
-  grid-template-rows: repeat(2, 1fr);
-  grid-template-columns: repeat(8, 1fr);
-  grid-auto-flow: column;
-
+  display: flex;
   @include mobile {
     overflow-x: scroll;
     height: 185px;
-    column-gap: 50px;
-    row-gap: 20px;
+    gap: 16px;
   }
   @include tablet {
     overflow-x: scroll;
     height: 386px;
-    column-gap: 30px;
-    row-gap: 64px;
+    gap: 24px;
   }
   @include desktop {
     overflow-x: hidden;
     max-width: 900px;
     height: 386px;
-    column-gap: 30px;
-    row-gap: 64px;
+    gap: 24px;
   }
 }
 
-.item {
-  position: relative;
+.card {
+  cursor: pointer;
+  background-color: #ffffff;
+  border-radius: 10px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
   @include mobile {
-    width: 138px;
-    height: 60px;
+    min-width: 194px;
+    height: 139px;
+    padding: 20px;
   }
   @include tablet {
-    width: 277px;
-    height: 161px;
+    min-width: 320px;
+    height: 300px;
+    padding: 63px 34px;
   }
   @include desktop {
-    width: 278px;
-    height: 161px;
+    min-width: 320px;
+    height: 300px;
+    padding: 63px 34px;
   }
 }
 
-.corporateLogoImage {
-  @include mobile {
-    width: 138px;
-    height: 60px;
-  }
-  @include tablet {
-    width: 278px;
-    height: 161px;
-  }
-  @include desktop {
-    width: 278px;
-    height: 121px;
-  }
-}
+.cardTitle {
+  display: -webkit-box;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  word-break: break-all;
 
-.name {
-  color: rgba(253, 253, 253, 0.8);
-  text-align: center;
-  font-weight: 400;
+  color: #262626;
+  font-weight: 500;
   @include mobile {
     font-size: 12px;
-    line-height: 19px;
+    line-height: 20px;
   }
   @include tablet {
     font-size: 25px;
@@ -142,5 +164,38 @@
   @include desktop {
     font-size: 25px;
     line-height: 40px;
+  }
+}
+
+.desc {
+  display:flex;
+  justify-content: space-between;
+  align-items: center;
+  color: #7d7d7d;
+  font-weight: 500;
+  word-break: keep-all;
+  @include mobile {
+    font-size: 12px;
+  }
+  @include tablet {
+    font-size: 25px;
+  }
+  @include desktop {
+    font-size: 25px;
+  }
+}
+
+.arrow {
+  @include mobile {
+    width: 17px;
+    height: 15px;
+  }
+  @include tablet {
+    width: 30px;
+    height: 30px;
+  }
+  @include desktop {
+    width: 30px;
+    height: 30px;
   }
 }

--- a/src/views/MainPage/components/ActivityReview/activity-review.module.scss
+++ b/src/views/MainPage/components/ActivityReview/activity-review.module.scss
@@ -1,0 +1,146 @@
+@import '@src/views/MainPage/stylesheets/mixins';
+
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  @include mobile {
+    width: 90%;
+    gap: 48px;
+  }
+  @include tablet {
+    width: 75%;
+    gap: 100px;
+  }
+  @include desktop {
+    width: 100%;
+    gap: 100px;
+  }
+}
+
+.titleWrapper {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.title {
+  font-weight: 800;
+  white-space: pre-wrap;
+  @include mobile {
+    font-size: 20px;
+    line-height: 28px;
+  }
+  @include tablet {
+    font-size: 36px;
+    line-height: 56px;
+  }
+  @include desktop {
+    width: 100%;
+    font-size: 45px;
+    line-height: 60px;
+  }
+}
+
+.contentWrapper {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.arrowWrapper {
+  @include mobile {
+    display: none;
+  }
+  @include tablet {
+    display: none;
+  }
+  @include desktop {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 64px;
+    height: 64px;
+    border-radius: 50%;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    cursor: pointer;
+  }
+}
+
+.content {
+  display: grid;
+  grid-template-rows: repeat(2, 1fr);
+  grid-template-columns: repeat(8, 1fr);
+  grid-auto-flow: column;
+
+  @include mobile {
+    overflow-x: scroll;
+    height: 185px;
+    column-gap: 50px;
+    row-gap: 20px;
+  }
+  @include tablet {
+    overflow-x: scroll;
+    height: 386px;
+    column-gap: 30px;
+    row-gap: 64px;
+  }
+  @include desktop {
+    overflow-x: hidden;
+    max-width: 900px;
+    height: 386px;
+    column-gap: 30px;
+    row-gap: 64px;
+  }
+}
+
+.item {
+  position: relative;
+  @include mobile {
+    width: 138px;
+    height: 60px;
+  }
+  @include tablet {
+    width: 277px;
+    height: 161px;
+  }
+  @include desktop {
+    width: 278px;
+    height: 161px;
+  }
+}
+
+.corporateLogoImage {
+  @include mobile {
+    width: 138px;
+    height: 60px;
+  }
+  @include tablet {
+    width: 278px;
+    height: 161px;
+  }
+  @include desktop {
+    width: 278px;
+    height: 121px;
+  }
+}
+
+.name {
+  color: rgba(253, 253, 253, 0.8);
+  text-align: center;
+  font-weight: 400;
+  @include mobile {
+    font-size: 12px;
+    line-height: 19px;
+  }
+  @include tablet {
+    font-size: 25px;
+    line-height: 40px;
+  }
+  @include desktop {
+    font-size: 25px;
+    line-height: 40px;
+  }
+}

--- a/src/views/MainPage/components/ActivityReview/activity-review.module.scss
+++ b/src/views/MainPage/components/ActivityReview/activity-review.module.scss
@@ -103,19 +103,17 @@
   display: flex;
   @include mobile {
     overflow-x: scroll;
-    height: 185px;
     gap: 16px;
   }
   @include tablet {
     overflow-x: scroll;
-    height: 386px;
     gap: 24px;
   }
   @include desktop {
+    margin: 0 32px;
     overflow-x: hidden;
-    max-width: 900px;
-    height: 386px;
     gap: 24px;
+    max-width: 1008px;
   }
 }
 
@@ -123,6 +121,7 @@
   cursor: pointer;
   background-color: #ffffff;
   border-radius: 10px;
+  font-family: 'Pretendard';
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -134,12 +133,12 @@
   @include tablet {
     min-width: 320px;
     height: 300px;
-    padding: 63px 34px;
+    padding: 38px 34px;
   }
   @include desktop {
     min-width: 320px;
     height: 300px;
-    padding: 63px 34px;
+    padding: 38px 34px;
   }
 }
 
@@ -150,7 +149,6 @@
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 3;
   word-break: break-all;
-
   color: #262626;
   font-weight: 500;
   @include mobile {
@@ -170,10 +168,10 @@
 .desc {
   display:flex;
   justify-content: space-between;
-  align-items: center;
-  color: #7d7d7d;
+  align-items: flex-end;
+  white-space: pre-wrap;
+  color: rgba(38, 38, 38, 0.6);
   font-weight: 500;
-  word-break: keep-all;
   @include mobile {
     font-size: 12px;
   }
@@ -182,6 +180,14 @@
   }
   @include desktop {
     font-size: 25px;
+    line-height: 40px;
+  }
+}
+
+.descName {
+  font-weight: 700;
+  @include mobile {
+    font-weight: 500;
   }
 }
 

--- a/src/views/MainPage/components/ActivityReview/hooks/useFetch.ts
+++ b/src/views/MainPage/components/ActivityReview/hooks/useFetch.ts
@@ -1,0 +1,11 @@
+import useFetchBase from '@src/hooks/useFetchBase';
+import { getSampleReviews } from '@src/lib/review';
+import { useCallback } from 'react';
+
+const useFetch = () => {
+  const willFetch = useCallback(() => getSampleReviews(), []);
+  const state = useFetchBase(willFetch);
+  return state;
+};
+
+export default useFetch;

--- a/src/views/MainPage/components/ActivityReview/utils/parsePartToKorean.ts
+++ b/src/views/MainPage/components/ActivityReview/utils/parsePartToKorean.ts
@@ -1,0 +1,19 @@
+import { TAB } from '@src/views/ReviewPage/types';
+
+// TODO :: ReviewType의 part 타입을 string -> TAB 변경
+export function parsePartToKorean(part: string) {
+  switch (part) {
+    case TAB.ANDROID:
+      return '안드로이드';
+    case TAB.WEB:
+      return '웹';
+    case TAB.DESIGN:
+      return '디자인';
+    case TAB.PLAN:
+      return '기획';
+    case TAB.SERVER:
+      return '서버';
+    default:
+      return part;
+  }
+}

--- a/src/views/MainPage/components/CorporateLinkedActivities/corporate-linked-activities.module.scss
+++ b/src/views/MainPage/components/CorporateLinkedActivities/corporate-linked-activities.module.scss
@@ -89,10 +89,20 @@
 }
 
 .contentWrapper {
-  width: 100%;
   display: flex;
   justify-content: space-between;
   align-items: center;
+  @include mobile {
+    width: 100vw;
+    padding: 0 16px;
+  }
+  @include tablet {
+    width: 100vw;
+    padding: 0 24px;
+  }
+  @include desktop {
+    width: 100%;
+  }
 }
 
 .content {

--- a/src/views/MainPage/components/SoptHistory/sopt-history.module.scss
+++ b/src/views/MainPage/components/SoptHistory/sopt-history.module.scss
@@ -16,7 +16,7 @@
   @include desktop {
     align-items: flex-start;
     justify-content: space-around;
-    width: 1100px;
+    width: 1200px;
     height: 502px;
   }
 }

--- a/src/views/MainPage/components/index.ts
+++ b/src/views/MainPage/components/index.ts
@@ -5,3 +5,4 @@ export * from './DetailedInformation/DetailedInformation';
 export * from './PartDescription/PartDescription';
 export * from './CorporatePartner/CorporatePartner';
 export * from './CorporateLinkedActivities/CorporateLinkedActivities';
+export * from './ActivityReview/ActivityReview';

--- a/src/views/MainPage/main-page.module.scss
+++ b/src/views/MainPage/main-page.module.scss
@@ -21,7 +21,7 @@
     gap: 150px;
   }
   @include desktop {
-    max-width: 1100px;
+    max-width: 1200px;
     gap: 190px;
   }
 }

--- a/src/views/ProjectPage/hooks/useFetch.ts
+++ b/src/views/ProjectPage/hooks/useFetch.ts
@@ -1,40 +1,11 @@
-import { to } from 'await-to-js';
-import { useEffect, useReducer } from 'react';
-import { getProjectByCategory, getProjectList } from '@src/lib/project';
+import { useCallback } from 'react';
+import useFetchBase from '@src/hooks/useFetchBase';
+import { getProjectList } from '@src/lib/project';
 import { ProjectCategoryType } from '../lib/constants';
-import { reducer } from '../lib/reducer';
-import type { ProjectType, State } from '../types';
 
-const useFetch = (selected: ProjectCategoryType): State<ProjectType> => {
-  const [state, dispatch] = useReducer(reducer, { _TAG: 'IDLE' });
-
-  useEffect(() => {
-    const fetchProjectList = async () => {
-      /* selected 가 Undefined가 아니면 getProjectByCategory 호출, 아니면 getProjectList 호출*/
-      const willFetch =
-        selected === ProjectCategoryType.ALL ? getProjectList : getProjectByCategory;
-
-      dispatch({
-        _TAG: 'FETCH',
-      });
-
-      const [error, response] = await to(willFetch(selected));
-
-      if (error) {
-        return dispatch({
-          _TAG: 'FAILED',
-          error,
-        });
-      }
-
-      if (response) {
-        return dispatch({ _TAG: 'SUCCESS', data: response });
-      }
-    };
-
-    fetchProjectList();
-  }, [selected]);
-
+const useFetch = (selected: ProjectCategoryType) => {
+  const willFetch = useCallback(() => getProjectList(selected), [selected]);
+  const state = useFetchBase(willFetch);
   return state;
 };
 

--- a/src/views/ProjectPage/types.ts
+++ b/src/views/ProjectPage/types.ts
@@ -27,32 +27,3 @@ export interface ProjectType {
   updatedAt: string;
   uploadedAt: string;
 }
-
-export type State<T> =
-  | {
-      _TAG: 'IDLE';
-    }
-  | {
-      _TAG: 'LOADING';
-    }
-  | {
-      _TAG: 'ERROR';
-      error: Error;
-    }
-  | {
-      _TAG: 'OK';
-      data: T[];
-    };
-
-export type Action<T> =
-  | {
-      _TAG: 'FETCH';
-    }
-  | {
-      _TAG: 'FAILED';
-      error: Error;
-    }
-  | {
-      _TAG: 'SUCCESS';
-      data: T[];
-    };

--- a/src/views/ReviewPage/ReviewPage.tsx
+++ b/src/views/ReviewPage/ReviewPage.tsx
@@ -1,11 +1,22 @@
 import styled from '@emotion/styled';
-import { Footer, Header, Layout } from '@src/components';
+import { useState } from 'react';
+import { Footer, Header, Layout, ScrollToTopButton } from '@src/components';
+import Description from './components/Description';
+import Reviews from './components/Reviews';
+import TabBar from './components/TabBar';
+import { TAB } from './types';
 
 function ReviewPage() {
+  const [selectedTab, setSelectedTab] = useState(TAB.ALL);
   return (
     <Layout>
       <Header />
-      <Root>hello</Root>
+      <ScrollToTopButton />
+      <Root>
+        <Description />
+        <TabBar onTabClick={setSelectedTab} selectedTab={selectedTab} />
+        <Reviews selectedTab={selectedTab} />
+      </Root>
       <Footer />
     </Layout>
   );
@@ -20,11 +31,13 @@ const Root = styled.div`
   margin: 0 auto;
 
   /* 태블릿 뷰 */
-  @media (max-width: 1919px) and (min-width: 766px) {
-    width: 766px;
+  @media (max-width: 1199px) and (min-width: 766px) {
+    width: 700px;
+    margin-top: 90px;
   }
   /* 모바일 뷰 */
   @media (max-width: 765.9px) {
     width: 360px;
+    margin-top: 90px;
   }
 `;

--- a/src/views/ReviewPage/components/Description/index.tsx
+++ b/src/views/ReviewPage/components/Description/index.tsx
@@ -1,0 +1,34 @@
+import styled from '@emotion/styled';
+import { mainColor } from '@src/assets/sopt/mainColor';
+
+const Description = () => {
+  return <Title>SOPT 회원들의 활동 후기</Title>;
+};
+
+const Title = styled.div`
+  font-weight: 700;
+  color: ${mainColor.white};
+  text-align: center;
+
+  /* 데스크탑 뷰 */
+  @media (min-width: 1124px) {
+    margin-top: 120px;
+    margin-bottom: 54px;
+    font-size: 40px;
+  }
+
+  /* 태블릿 뷰 */
+  @media (max-width: 1123px) {
+    margin-top: 70px;
+    margin-bottom: 52px;
+    font-size: 36px;
+  }
+
+  /* 태블릿 뷰 */
+  @media (max-width: 765.9px) {
+    margin-top: 32px;
+    font-size: 20px;
+  }
+`;
+
+export default Description;

--- a/src/views/ReviewPage/components/Reviews/index.tsx
+++ b/src/views/ReviewPage/components/Reviews/index.tsx
@@ -1,0 +1,49 @@
+import { useMemo } from 'react';
+import { useIsMobile } from '@src/hooks/useDevice';
+import useFetch from '../../hooks/useFetch';
+import { TAB } from '../../types';
+import * as S from './style';
+
+type ReviewsProps = {
+  selectedTab: TAB;
+};
+
+const Reviews = ({ selectedTab }: ReviewsProps) => {
+  const reviews = useFetch(selectedTab);
+  const isMobile = useIsMobile();
+  const imageHeight = useMemo(() => (isMobile ? 216 : 240), [isMobile]);
+
+  if (reviews._TAG !== 'OK') return null;
+
+  return (
+    <S.Wrapper>
+      {reviews.data.map((review) => (
+        <S.Card key={review.id} href={review.link} target="_blank">
+          <S.Section>
+            <S.ThumbnailWrapper css={{ height: imageHeight }}>
+              <S.Thumbnail
+                src={
+                  review.thumbnail ??
+                  'https://static.wikia.nocookie.net/pokemon/images/3/3c/%EB%9D%BC%EC%9D%B4%EC%B8%84_%EA%B3%B5%EC%8B%9D_%EC%9D%BC%EB%9F%AC%EC%8A%A4%ED%8A%B8.png/revision/latest?cb=20170405000124&path-prefix=ko'
+                }
+                alt={review.title}
+                objectFit="cover"
+                layout="fill"
+              />
+            </S.ThumbnailWrapper>
+            <S.ChipWrapper>
+              <S.Chip>{review.part}</S.Chip>
+              <S.Chip>{review.semester}기</S.Chip>
+            </S.ChipWrapper>
+          </S.Section>
+          <S.Section>
+            <S.Title>{review.title}</S.Title>
+            <S.Desc>{review.subject}</S.Desc>
+          </S.Section>
+        </S.Card>
+      ))}
+    </S.Wrapper>
+  );
+};
+
+export default Reviews;

--- a/src/views/ReviewPage/components/Reviews/style.ts
+++ b/src/views/ReviewPage/components/Reviews/style.ts
@@ -1,0 +1,102 @@
+import styled from '@emotion/styled';
+import Image from 'next/image';
+import { css } from '@emotion/react';
+
+export const Wrapper = styled.div`
+  display: flex;
+  column-gap: 30px;
+  row-gap: 80px;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-top: 72px;
+  margin-bottom: 212px;
+
+  /* 태블릿 뷰 */
+  @media (max-width: 1199px) and (min-width: 766px) {
+    row-gap: 52px;
+    margin-top: 52px;
+    margin-bottom: 144px;
+  }
+  /* 모바일 뷰 */
+  @media (max-width: 765.9px) {
+    width: 360px;
+    margin-top: 52px;
+    margin-bottom: 84px;
+  }
+`;
+
+export const Card = styled.a`
+  text-decoration: none;
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+
+  width: 360px;
+
+  /* 태블릿 뷰 */
+  @media (max-width: 1199px) and (min-width: 766px) {
+    width: 316px;
+  }
+  /* 모바일 뷰 */
+  @media (max-width: 765.9px) {
+    width: 360px;
+  }
+`;
+
+export const Section = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+`;
+
+export const ThumbnailWrapper = styled.div`
+  width: 100%;
+  position: relative;
+`;
+
+export const Thumbnail = styled(Image)`
+  width: 100%;
+  border-radius: 5px;
+`;
+
+export const ChipWrapper = styled.div`
+  display: flex;
+  gap: 8px;
+`;
+export const Chip = styled.div`
+  color: #ffffff;
+  font-size: 16px;
+  padding: 10px 12px;
+  background-color: #000000;
+  border-radius: 10px;
+`;
+
+const textEllipsis = css`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+export const Title = styled.div`
+  font-weight: 700;
+  font-size: 28px;
+  color: #ffffff;
+
+  /* 모바일 뷰 */
+  @media (max-width: 765.9px) {
+    font-size: 20px;
+  }
+
+  ${textEllipsis}
+`;
+
+export const Desc = styled.div`
+  color: #bebebe;
+  font-size: 18px;
+
+  /* 모바일 뷰 */
+  @media (max-width: 765.9px) {
+    font-size: 15px;
+  }
+  ${textEllipsis}
+`;

--- a/src/views/ReviewPage/components/TabBar/index.tsx
+++ b/src/views/ReviewPage/components/TabBar/index.tsx
@@ -1,0 +1,37 @@
+import { tabs } from '../../libs/constants';
+import { TAB, TabType } from '../../types';
+import * as S from './style';
+
+type TabBarProps = {
+  selectedTab: TAB;
+  onTabClick(targetTab: TAB): void;
+};
+
+const TabBar = ({ onTabClick, selectedTab }: TabBarProps) => {
+  return (
+    <S.TabBar>
+      {tabs.map((tab) => (
+        <Tab
+          key={tab.value}
+          onClick={() => onTabClick(tab.value)}
+          tab={tab}
+          selected={selectedTab === tab.value}
+        />
+      ))}
+    </S.TabBar>
+  );
+};
+
+type TabProps = {
+  onClick(): void;
+  tab: TabType;
+  selected: boolean;
+};
+
+const Tab = ({ onClick, tab, selected }: TabProps) => (
+  <S.Tab selected={selected} onClick={onClick}>
+    {tab.label}
+  </S.Tab>
+);
+
+export default TabBar;

--- a/src/views/ReviewPage/components/TabBar/style.ts
+++ b/src/views/ReviewPage/components/TabBar/style.ts
@@ -1,0 +1,27 @@
+import styled from '@emotion/styled';
+
+export const TabBar = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 12px;
+`;
+
+export const Tab = styled.div<{ selected: boolean }>`
+  cursor: pointer;
+  text-align: center;
+  padding: 20px 0;
+  border-radius: 10px;
+  color: ${({ selected }) => (selected ? '#FFFFFF' : '#cccccc')};
+  background-color: ${({ selected }) => (selected ? '#FFFFFF1A' : 'inherit')};
+  font-size: 18px;
+
+  min-width: 160px;
+
+  /* 태블릿 뷰 */
+  @media (max-width: 765.9px) {
+    min-width: 72px;
+    padding: 12px 0;
+    font-size: 12px;
+  }
+`;

--- a/src/views/ReviewPage/components/index.ts
+++ b/src/views/ReviewPage/components/index.ts
@@ -1,0 +1,3 @@
+export * from './Description';
+export * from './Reviews';
+export * from './TabBar';

--- a/src/views/ReviewPage/hooks/useFetch.ts
+++ b/src/views/ReviewPage/hooks/useFetch.ts
@@ -1,0 +1,12 @@
+import { useCallback } from 'react';
+import useFetchBase from '@src/hooks/useFetchBase';
+import { getReviews } from '@src/lib/review';
+import { TAB } from '../types';
+
+const useFetch = (selected: TAB) => {
+  const willFetch = useCallback(() => getReviews(selected), [selected]);
+  const state = useFetchBase(willFetch);
+  return state;
+};
+
+export default useFetch;

--- a/src/views/ReviewPage/libs/constants.ts
+++ b/src/views/ReviewPage/libs/constants.ts
@@ -1,0 +1,32 @@
+import { TAB, TabType } from '../types';
+
+export const tabs: TabType[] = [
+  {
+    value: TAB.ALL,
+    label: '전체',
+  },
+  {
+    value: TAB.PLAN,
+    label: '기획',
+  },
+  {
+    value: TAB.DESIGN,
+    label: '디자인',
+  },
+  {
+    value: TAB.ANDROID,
+    label: '안드로이드',
+  },
+  {
+    value: TAB.IOS,
+    label: 'iOS',
+  },
+  {
+    value: TAB.WEB,
+    label: '웹',
+  },
+  {
+    value: TAB.SERVER,
+    label: '서버',
+  },
+];

--- a/src/views/ReviewPage/types/index.tsx
+++ b/src/views/ReviewPage/types/index.tsx
@@ -1,0 +1,26 @@
+export enum TAB {
+  ALL = 'ALL',
+  PLAN = 'PLAN',
+  DESIGN = 'DESIGN',
+  ANDROID = 'ANDROID',
+  IOS = 'iOS',
+  WEB = 'WEB',
+  SERVER = 'SERVER',
+}
+
+export type TabType = {
+  value: TAB;
+  label: string;
+};
+
+export type ReviewType = {
+  id: number;
+  title: string;
+  reviewer: string;
+  semester: number;
+  part: string;
+  subject: string;
+  thumbnail: string;
+  platform: string;
+  link: string;
+};


### PR DESCRIPTION
## Summary
- https://github.com/sopt-makers/sopt.org-frontend/pull/83 사항 머지하여 진행하였습니다. 제 커밋만 보시면 될 것 같아요 !
- `MainPage/components/ActivityReviews` 컴포넌트에요. 위아래에서 컴포넌트를 잘게 안쪼개길래, 저도 그냥 다 넣었어요. 피드백 환영합니다!
- 저엉말 반응형 작업 오랜만에 해서 처참한 css 능력이 탄로나었습니다.. 뚝딱 하고 작업 도와주고 싶었는데😭😭 미안해요

## Screenshot

https://user-images.githubusercontent.com/47105088/226116370-fc0f3597-f3b2-46a5-b0c3-5be3df45efea.mp4


https://user-images.githubusercontent.com/47105088/226116377-dcc14a47-8a63-4232-9d5a-6fc2e052cec0.mp4



## Comment
- `useFetch` 훅이랑 util 폴더를 결국 컴포넌트 폴터 내에 생성했어요 ..! 컴포넌트 내에서만 사용할 것 같아서요! 피드백 환영합니닷
- 데스크탑 뷰의 양 옆 마진을 제외한 메인 width 가 1100px로 설정되어 있었는데, 피그마에는 1200이더군요?? 활동후기 레이아웃이 깨지길래 1100px -> 1200px 변경하였습니다 (3군데)
- scss 좋네요 ,,! css-in-js와 장단점이 뚜렷한 것 같아요 하하