### PR TITLE
sp0 활동 후기 무한 스크롤

### DIFF
--- a/src/hooks/useBooleanState.ts
+++ b/src/hooks/useBooleanState.ts
@@ -1,0 +1,19 @@
+import { useCallback, useState } from 'react';
+
+export default function useBooleanState(defaultValue = false) {
+  const [bool, setBool] = useState(defaultValue);
+
+  const setTrue = useCallback(() => {
+    setBool(true);
+  }, []);
+
+  const setFalse = useCallback(() => {
+    setBool(false);
+  }, []);
+
+  const toggle = useCallback(() => {
+    setBool((b) => !b);
+  }, []);
+
+  return [bool, setTrue, setFalse, toggle] as const;
+}

--- a/src/hooks/useIntersectionObserver.ts
+++ b/src/hooks/useIntersectionObserver.ts
@@ -1,0 +1,28 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+type IntersectHandler = (entry: IntersectionObserverEntry, observer: IntersectionObserver) => void;
+
+const useIntersectionObserver = (onIntersect: IntersectHandler, options?: IntersectionObserverInit) => {
+  const ref = useRef<HTMLDivElement>(null);
+  const callback = useCallback(
+    (entries: IntersectionObserverEntry[], observer: IntersectionObserver) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          onIntersect(entry, observer);
+        }
+      });
+    },
+    [onIntersect],
+  );
+
+  useEffect(() => {
+    if (!ref.current) return;
+    const observer = new IntersectionObserver(callback, options);
+    observer.observe(ref.current);
+    return () => observer.disconnect();
+  }, [ref, options, callback]);
+
+  return ref;
+};
+
+export default useIntersectionObserver;

--- a/src/hooks/useStackedFetchBase.ts
+++ b/src/hooks/useStackedFetchBase.ts
@@ -1,0 +1,41 @@
+import { to } from 'await-to-js';
+import { useEffect, useReducer, useRef } from 'react';
+import { reducer } from './useFetchBase/reducer';
+import { Action, State } from './useFetchBase/types';
+
+function useStackedFetchBase<T>(willFetch: () => Promise<T[]>): State<T> {
+  const [state, dispatch] = useReducer<React.Reducer<State<T>, Action<T>>>(reducer, {
+    _TAG: 'IDLE',
+  });
+  const stateStack = useRef<T[]>([]);
+
+  useEffect(() => {
+    const fetchProjectList = async () => {
+      dispatch({
+        _TAG: 'FETCH',
+      });
+
+      const [error, response] = await to(willFetch());
+
+      if (error) {
+        return dispatch({
+          _TAG: 'FAILED',
+          error,
+        });
+      }
+
+      if (response) {
+        const newState = [...stateStack.current, ...response];
+
+        dispatch({ _TAG: 'SUCCESS', data: newState });
+        stateStack.current = newState;
+      }
+    };
+
+    fetchProjectList();
+  }, [willFetch]);
+
+  return state;
+}
+
+export default useStackedFetchBase;

--- a/src/hooks/useStackedFetchBase/index.ts
+++ b/src/hooks/useStackedFetchBase/index.ts
@@ -1,7 +1,7 @@
 import { to } from 'await-to-js';
 import { useEffect, useReducer, useRef } from 'react';
-import { reducer } from './useFetchBase/reducer';
-import { Action, State } from './useFetchBase/types';
+import { reducer } from './reducer';
+import { Action, State } from './types';
 
 function useStackedFetchBase<T>(willFetch: () => Promise<T[]>): State<T> {
   const [state, dispatch] = useReducer<React.Reducer<State<T>, Action<T>>>(reducer, {
@@ -13,6 +13,7 @@ function useStackedFetchBase<T>(willFetch: () => Promise<T[]>): State<T> {
     const fetchProjectList = async () => {
       dispatch({
         _TAG: 'FETCH',
+        data: stateStack.current,
       });
 
       const [error, response] = await to(willFetch());

--- a/src/hooks/useStackedFetchBase/index.ts
+++ b/src/hooks/useStackedFetchBase/index.ts
@@ -1,19 +1,22 @@
 import { to } from 'await-to-js';
-import { useEffect, useReducer, useRef } from 'react';
+import { useEffect, useReducer } from 'react';
 import { reducer } from './reducer';
 import { Action, State } from './types';
 
-function useStackedFetchBase<T>(willFetch: () => Promise<T[]>, isInitialFetching: boolean): State<T> {
+function useStackedFetchBase<T>(
+  willFetch: () => Promise<T[]>,
+  isInitialFetching: boolean,
+): State<T> {
   const [state, dispatch] = useReducer<React.Reducer<State<T>, Action<T>>>(reducer, {
     _TAG: 'IDLE',
+    data: [],
   });
-  const stateStack = useRef<T[]>([]);
 
   useEffect(() => {
     const fetchProjectList = async () => {
       dispatch({
         _TAG: 'FETCH',
-        data: isInitialFetching ? [] : stateStack.current,
+        isInitialFetching,
       });
 
       const [error, response] = await to(willFetch());
@@ -26,13 +29,10 @@ function useStackedFetchBase<T>(willFetch: () => Promise<T[]>, isInitialFetching
       }
 
       if (response) {
-        const newState = isInitialFetching ? [...response] : [...stateStack.current, ...response];
-
-        dispatch({ _TAG: 'SUCCESS', data: newState });
-        stateStack.current = newState;
+        dispatch({ _TAG: 'SUCCESS', isInitialFetching, data: response });
       }
     };
-    
+
     fetchProjectList();
   }, [willFetch, isInitialFetching]);
 

--- a/src/hooks/useStackedFetchBase/reducer.ts
+++ b/src/hooks/useStackedFetchBase/reducer.ts
@@ -6,7 +6,7 @@ export function reducer<T>(prevState: State<T>, action: Action<T>): State<T> {
       if (action._TAG === 'FETCH') {
         return {
           _TAG: 'LOADING',
-          data: action.data,
+          data: action.isInitialFetching ? [] : prevState.data,
         };
       }
       break;
@@ -20,7 +20,7 @@ export function reducer<T>(prevState: State<T>, action: Action<T>): State<T> {
       if (action._TAG === 'SUCCESS') {
         return {
           _TAG: 'OK',
-          data: action.data,
+          data: action.isInitialFetching ? action.data : [...prevState.data, ...action.data],
         };
       }
       break;
@@ -28,7 +28,7 @@ export function reducer<T>(prevState: State<T>, action: Action<T>): State<T> {
       if (action._TAG === 'FETCH') {
         return {
           _TAG: 'LOADING',
-          data: action.data,
+          data: action.isInitialFetching ? [] : prevState.data,
         };
       }
       break;

--- a/src/hooks/useStackedFetchBase/reducer.ts
+++ b/src/hooks/useStackedFetchBase/reducer.ts
@@ -1,0 +1,40 @@
+import type { Action, State } from './types';
+
+export function reducer<T>(prevState: State<T>, action: Action<T>): State<T> {
+  switch (prevState._TAG) {
+    case 'IDLE':
+      if (action._TAG === 'FETCH') {
+        return {
+          _TAG: 'LOADING',
+          data: action.data,
+        };
+      }
+      break;
+    case 'LOADING':
+      if (action._TAG === 'FAILED') {
+        return {
+          _TAG: 'ERROR',
+          error: action.error,
+        };
+      }
+      if (action._TAG === 'SUCCESS') {
+        return {
+          _TAG: 'OK',
+          data: action.data,
+        };
+      }
+      break;
+    case 'OK':
+      if (action._TAG === 'FETCH') {
+        return {
+          _TAG: 'LOADING',
+          data: action.data,
+        };
+      }
+      break;
+    default:
+      throw new Error(`Unknown action type: ${action._TAG}`);
+  }
+
+  return prevState;
+}

--- a/src/hooks/useStackedFetchBase/types.ts
+++ b/src/hooks/useStackedFetchBase/types.ts
@@ -1,6 +1,7 @@
 export type State<T> =
   | {
       _TAG: 'IDLE';
+      data: T[];
     }
   | {
       _TAG: 'LOADING';
@@ -18,7 +19,7 @@ export type State<T> =
 export type Action<T> =
   | {
       _TAG: 'FETCH';
-      data: T[];
+      isInitialFetching: boolean;
     }
   | {
       _TAG: 'FAILED';
@@ -26,5 +27,6 @@ export type Action<T> =
     }
   | {
       _TAG: 'SUCCESS';
+      isInitialFetching: boolean;
       data: T[];
     };

--- a/src/hooks/useStackedFetchBase/types.ts
+++ b/src/hooks/useStackedFetchBase/types.ts
@@ -1,0 +1,30 @@
+export type State<T> =
+  | {
+      _TAG: 'IDLE';
+    }
+  | {
+      _TAG: 'LOADING';
+      data: T[];
+    }
+  | {
+      _TAG: 'ERROR';
+      error: Error;
+    }
+  | {
+      _TAG: 'OK';
+      data: T[];
+    };
+
+export type Action<T> =
+  | {
+      _TAG: 'FETCH';
+      data: T[];
+    }
+  | {
+      _TAG: 'FAILED';
+      error: Error;
+    }
+  | {
+      _TAG: 'SUCCESS';
+      data: T[];
+    };

--- a/src/lib/review.ts
+++ b/src/lib/review.ts
@@ -7,12 +7,20 @@ const client = axios.create({
   timeout: 3000,
 });
 
-export const getReviews = async (tab: TAB, pageNo = 1): Promise<ReviewType[]> => {
+export const getReviews = async (
+  tab: TAB,
+  pageNo = 1,
+  setIsStartToGetReviews: () => void,
+  setIsEndToGetReviews: () => void,
+): Promise<ReviewType[]> => {
   const partParameter = tab === TAB.ALL ? {} : { part: tab };
   const pageParameter = { pageNo, limit: 6 };
   const parameter = qs.stringify({ ...partParameter, ...pageParameter });
 
   const { data } = await client.get(`/reviews?${parameter}`);
+
+  data.hasNextPage ? setIsStartToGetReviews() : setIsEndToGetReviews();
+
   return data.data;
 };
 

--- a/src/lib/review.ts
+++ b/src/lib/review.ts
@@ -10,8 +10,8 @@ const client = axios.create({
 export const getReviews = async (
   tab: TAB,
   pageNo = 1,
-  setIsStartToGetReviews: () => void,
-  setIsEndToGetReviews: () => void,
+  setCanGetMoreReviews: () => void,
+  setCanNotGetMoreReviews: () => void,
 ): Promise<ReviewType[]> => {
   const partParameter = tab === TAB.ALL ? {} : { part: tab };
   const pageParameter = { pageNo, limit: 6 };
@@ -19,7 +19,7 @@ export const getReviews = async (
 
   const { data } = await client.get(`/reviews?${parameter}`);
 
-  data.hasNextPage ? setIsStartToGetReviews() : setIsEndToGetReviews();
+  data.hasNextPage ? setCanGetMoreReviews() : setCanNotGetMoreReviews();
 
   return data.data;
 };

--- a/src/lib/review.ts
+++ b/src/lib/review.ts
@@ -7,9 +7,9 @@ const client = axios.create({
   timeout: 3000,
 });
 
-export const getReviews = async (tab: TAB): Promise<ReviewType[]> => {
+export const getReviews = async (tab: TAB, pageNo = 1): Promise<ReviewType[]> => {
   const partParameter = tab === TAB.ALL ? {} : { part: tab };
-  const pageParameter = { pageNo: 1, limit: '120' };
+  const pageParameter = { pageNo, limit: 6 };
   const parameter = qs.stringify({ ...partParameter, ...pageParameter });
 
   const { data } = await client.get(`/reviews?${parameter}`);

--- a/src/styles/textEllipsis.ts
+++ b/src/styles/textEllipsis.ts
@@ -1,0 +1,14 @@
+import { css } from '@emotion/react';
+
+export const textSingularLineEllipsis = css`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+export const textpluralLinesEllipsis = (lines: number) => css`
+  text-overflow: ellipsis;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: ${lines};
+  word-break: break-all;
+`;

--- a/src/views/ProjectPage/hooks/useInfiniteScroll.ts
+++ b/src/views/ProjectPage/hooks/useInfiniteScroll.ts
@@ -1,36 +1,12 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
-
-type IntersectHandler = (entry: IntersectionObserverEntry, observer: IntersectionObserver) => void;
-
-const useIntersect = (onIntersect: IntersectHandler, options?: IntersectionObserverInit) => {
-  const ref = useRef<HTMLDivElement>(null);
-  const callback = useCallback(
-    (entries: IntersectionObserverEntry[], observer: IntersectionObserver) => {
-      entries.forEach((entry) => {
-        if (entry.isIntersecting) {
-          onIntersect(entry, observer);
-        }
-      });
-    },
-    [onIntersect],
-  );
-
-  useEffect(() => {
-    if (!ref.current) return;
-    const observer = new IntersectionObserver(callback, options);
-    observer.observe(ref.current);
-    return () => observer.disconnect();
-  }, [ref, options, callback]);
-
-  return ref;
-};
+import useIntersectionObserver from '@src/hooks/useIntersectionObserver';
+import { useState } from 'react';
 
 export function useInfiniteScroll<T>(totalData: T[]) {
   const [count, setCount] = useState(1);
   const [data, setData] = useState(totalData.slice(0, 15));
   const isNextPage = totalData.length > 15 && count <= Math.ceil(totalData.length / 15);
 
-  const ref = useIntersect(
+  const ref = useIntersectionObserver(
     async (entry, observer) => {
       if (isNextPage) {
         setTimeout(() => {

--- a/src/views/ReviewPage/ReviewPage.tsx
+++ b/src/views/ReviewPage/ReviewPage.tsx
@@ -8,6 +8,7 @@ import { TAB } from './types';
 
 function ReviewPage() {
   const [selectedTab, setSelectedTab] = useState(TAB.ALL);
+
   return (
     <Layout>
       <Header />
@@ -28,6 +29,7 @@ const Root = styled.div`
   display: flex;
   flex-direction: column;
   width: 1200px;
+  min-height: 100vh;
   margin: 0 auto;
 
   /* 태블릿 뷰 */

--- a/src/views/ReviewPage/components/Reviews/index.tsx
+++ b/src/views/ReviewPage/components/Reviews/index.tsx
@@ -20,8 +20,8 @@ const Reviews = ({ selectedTab }: ReviewsProps) => {
   return (
     <>
       <S.Wrapper>
-        {reviews.data.map((review, idx) => (
-          <S.Card key={`${review.id}-${idx}`} href={review.link} target="_blank">
+        {reviews.data.map((review) => (
+          <S.Card key={review.id} href={review.link} target="_blank">
             <S.Section>
               <S.ThumbnailWrapper css={{ height: imageHeight }}>
                 <S.Thumbnail

--- a/src/views/ReviewPage/components/Reviews/index.tsx
+++ b/src/views/ReviewPage/components/Reviews/index.tsx
@@ -20,8 +20,8 @@ const Reviews = ({ selectedTab }: ReviewsProps) => {
   return (
     <>
       <S.Wrapper>
-        {reviews.data.map((review) => (
-          <S.Card key={review.id} href={review.link} target="_blank">
+        {reviews.data.map((review, idx) => (
+          <S.Card key={`${review.id}-${idx}`} href={review.link} target="_blank">
             <S.Section>
               <S.ThumbnailWrapper css={{ height: imageHeight }}>
                 <S.Thumbnail

--- a/src/views/ReviewPage/components/Reviews/index.tsx
+++ b/src/views/ReviewPage/components/Reviews/index.tsx
@@ -11,7 +11,7 @@ type ReviewsProps = {
 };
 
 const Reviews = ({ selectedTab }: ReviewsProps) => {
-  const reviews = useFetch(selectedTab);
+  const { state: reviews, ref } = useFetch(selectedTab);
   const isMobile = useIsMobile();
   const imageHeight = useMemo(() => (isMobile ? 216 : 240), [isMobile]);
 
@@ -19,10 +19,12 @@ const Reviews = ({ selectedTab }: ReviewsProps) => {
 
   if (reviews._TAG !== 'OK') return null;
 
+  console.log('reviews', reviews);
   return (
     <S.Wrapper>
-      {reviews.data.map((review) => (
-        <S.Card key={review.id} href={review.link} target="_blank">
+      {/* TODO :: idx key 값 임시 추가 삭제 */}
+      {reviews.data.map((review, idx) => (
+        <S.Card key={`${review.id}-${idx}`} href={review.link} target="_blank">
           <S.Section>
             <S.ThumbnailWrapper css={{ height: imageHeight }}>
               <S.Thumbnail
@@ -43,6 +45,16 @@ const Reviews = ({ selectedTab }: ReviewsProps) => {
           </S.Section>
         </S.Card>
       ))}
+      {
+        // <div className={styles['observered']} ref={ref}>
+        //   <div className={styles['spinner']}>
+        //     <OvalSpinner />
+        //   </div>
+        // </div>
+        <div ref={ref}>
+          <Loading />
+        </div>
+      }
     </S.Wrapper>
   );
 };

--- a/src/views/ReviewPage/components/Reviews/index.tsx
+++ b/src/views/ReviewPage/components/Reviews/index.tsx
@@ -1,9 +1,9 @@
 import { useMemo } from 'react';
 import { useIsMobile } from '@src/hooks/useDevice';
+import { OvalSpinner } from '@src/views/ProjectPage/components';
 import useFetch from '../../hooks/useFetch';
 import { logoPath } from '../../libs/constants';
 import { TAB } from '../../types';
-import Loading from './Loading';
 import * as S from './style';
 
 type ReviewsProps = {
@@ -15,47 +15,39 @@ const Reviews = ({ selectedTab }: ReviewsProps) => {
   const isMobile = useIsMobile();
   const imageHeight = useMemo(() => (isMobile ? 216 : 240), [isMobile]);
 
-  if (reviews._TAG === 'LOADING') return <Loading />;
+  if (!(reviews._TAG === 'OK' || reviews._TAG === 'LOADING')) return null;
 
-  if (reviews._TAG !== 'OK') return null;
-
-  console.log('reviews', reviews);
   return (
-    <S.Wrapper>
-      {/* TODO :: idx key 값 임시 추가 삭제 */}
-      {reviews.data.map((review, idx) => (
-        <S.Card key={`${review.id}-${idx}`} href={review.link} target="_blank">
-          <S.Section>
-            <S.ThumbnailWrapper css={{ height: imageHeight }}>
-              <S.Thumbnail
-                src={logoPath[review.semester]}
-                alt={review.title}
-                width={120}
-                height="100%"
-              />
-            </S.ThumbnailWrapper>
-            <S.ChipWrapper>
-              <S.Chip>{review.part}</S.Chip>
-              <S.Chip>{review.semester}기</S.Chip>
-            </S.ChipWrapper>
-          </S.Section>
-          <S.Section>
-            <S.Title>{review.title}</S.Title>
-            <S.Desc>{review.subject}</S.Desc>
-          </S.Section>
-        </S.Card>
-      ))}
-      {
-        // <div className={styles['observered']} ref={ref}>
-        //   <div className={styles['spinner']}>
-        //     <OvalSpinner />
-        //   </div>
-        // </div>
-        <div ref={ref}>
-          <Loading />
-        </div>
-      }
-    </S.Wrapper>
+    <>
+      <S.Wrapper>
+        {/* TODO :: idx key 값 임시 추가 삭제 */}
+        {reviews.data.map((review, idx) => (
+          <S.Card key={`${review.id}-${idx}`} href={review.link} target="_blank">
+            <S.Section>
+              <S.ThumbnailWrapper css={{ height: imageHeight }}>
+                <S.Thumbnail
+                  src={logoPath[review.semester]}
+                  alt={review.title}
+                  width={120}
+                  height="100%"
+                />
+              </S.ThumbnailWrapper>
+              <S.ChipWrapper>
+                <S.Chip>{review.part}</S.Chip>
+                <S.Chip>{review.semester}기</S.Chip>
+              </S.ChipWrapper>
+            </S.Section>
+            <S.Section>
+              <S.Title>{review.title}</S.Title>
+              <S.Desc>{review.subject}</S.Desc>
+            </S.Section>
+          </S.Card>
+        ))}
+      </S.Wrapper>
+      <S.SpinnerWrapper ref={ref}>
+        <OvalSpinner />
+      </S.SpinnerWrapper>
+    </>
   );
 };
 

--- a/src/views/ReviewPage/components/Reviews/index.tsx
+++ b/src/views/ReviewPage/components/Reviews/index.tsx
@@ -11,7 +11,7 @@ type ReviewsProps = {
 };
 
 const Reviews = ({ selectedTab }: ReviewsProps) => {
-  const { state: reviews, ref } = useFetch(selectedTab);
+  const { state: reviews, ref, canGetMoreReviews } = useFetch(selectedTab);
   const isMobile = useIsMobile();
   const imageHeight = useMemo(() => (isMobile ? 216 : 240), [isMobile]);
 
@@ -20,7 +20,6 @@ const Reviews = ({ selectedTab }: ReviewsProps) => {
   return (
     <>
       <S.Wrapper>
-        {/* TODO :: idx key 값 임시 추가 삭제 */}
         {reviews.data.map((review, idx) => (
           <S.Card key={`${review.id}-${idx}`} href={review.link} target="_blank">
             <S.Section>
@@ -44,9 +43,11 @@ const Reviews = ({ selectedTab }: ReviewsProps) => {
           </S.Card>
         ))}
       </S.Wrapper>
-      <S.SpinnerWrapper ref={ref}>
-        <OvalSpinner />
-      </S.SpinnerWrapper>
+      {canGetMoreReviews && (
+        <S.SpinnerWrapper ref={ref}>
+          <OvalSpinner />
+        </S.SpinnerWrapper>
+      )}
     </>
   );
 };

--- a/src/views/ReviewPage/components/Reviews/index.tsx
+++ b/src/views/ReviewPage/components/Reviews/index.tsx
@@ -44,7 +44,7 @@ const Reviews = ({ selectedTab }: ReviewsProps) => {
         ))}
       </S.Wrapper>
       {canGetMoreReviews && (
-        <S.SpinnerWrapper ref={ref}>
+        <S.SpinnerWrapper ref={reviews._TAG === 'LOADING' ? null : ref}>
           <OvalSpinner />
         </S.SpinnerWrapper>
       )}

--- a/src/views/ReviewPage/components/Reviews/style.ts
+++ b/src/views/ReviewPage/components/Reviews/style.ts
@@ -102,3 +102,10 @@ export const Desc = styled.div`
   }
   ${textEllipsis}
 `;
+
+export const SpinnerWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: 50px 0;
+`;

--- a/src/views/ReviewPage/components/Reviews/style.ts
+++ b/src/views/ReviewPage/components/Reviews/style.ts
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import Image from 'next/image';
-import { css } from '@emotion/react';
+import { textSingularLineEllipsis, textpluralLinesEllipsis } from '@src/styles/textEllipsis';
 
 export const Wrapper = styled.div`
   display: flex;
@@ -73,13 +73,8 @@ export const Chip = styled.div`
   border-radius: 10px;
 `;
 
-const textEllipsis = css`
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-`;
-
 export const Title = styled.div`
+  line-height: 140%;
   font-weight: 700;
   font-size: 28px;
   color: #ffffff;
@@ -89,7 +84,7 @@ export const Title = styled.div`
     font-size: 20px;
   }
 
-  ${textEllipsis}
+  ${textpluralLinesEllipsis(2)}
 `;
 
 export const Desc = styled.div`
@@ -100,7 +95,7 @@ export const Desc = styled.div`
   @media (max-width: 765.9px) {
     font-size: 15px;
   }
-  ${textEllipsis}
+  ${textSingularLineEllipsis}
 `;
 
 export const SpinnerWrapper = styled.div`

--- a/src/views/ReviewPage/hooks/useFetch.ts
+++ b/src/views/ReviewPage/hooks/useFetch.ts
@@ -1,12 +1,15 @@
 import { useCallback } from 'react';
-import useFetchBase from '@src/hooks/useFetchBase';
 import { getReviews } from '@src/lib/review';
 import { TAB } from '../types';
+import useInfiniteScroll from './useInfiniteScroll';
+import useStackedFetchBase from '@src/hooks/useStackedFetchBase';
 
 const useFetch = (selected: TAB) => {
-  const willFetch = useCallback(() => getReviews(selected), [selected]);
-  const state = useFetchBase(willFetch);
-  return state;
+  const { ref, count } = useInfiniteScroll();
+  const willFetch = useCallback(() => getReviews(selected, count), [selected, count]);
+  const state = useStackedFetchBase(willFetch);
+  
+  return { state, ref };
 };
 
 export default useFetch;

--- a/src/views/ReviewPage/hooks/useFetch.ts
+++ b/src/views/ReviewPage/hooks/useFetch.ts
@@ -17,6 +17,10 @@ const useFetch = (selected: TAB) => {
     };
   }, [selected, setCount, setCanGetMoreReviews]);
 
+  useEffect(() => {
+    console.log('selected, count', selected, count);
+  }, [selected, count]);
+
   const willFetch = useCallback(
     () => getReviews(selected, count, setCanGetMoreReviews, setCanNotGetMoreReviews),
     [selected, count, setCanGetMoreReviews, setCanNotGetMoreReviews],

--- a/src/views/ReviewPage/hooks/useFetch.ts
+++ b/src/views/ReviewPage/hooks/useFetch.ts
@@ -1,14 +1,21 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { getReviews } from '@src/lib/review';
 import { TAB } from '../types';
 import useInfiniteScroll from './useInfiniteScroll';
 import useStackedFetchBase from '@src/hooks/useStackedFetchBase';
 
 const useFetch = (selected: TAB) => {
-  const { ref, count } = useInfiniteScroll();
-  const willFetch = useCallback(() => getReviews(selected, count), [selected, count]);
-  const state = useStackedFetchBase(willFetch);
+  const { ref, count, setCount } = useInfiniteScroll();
   
+  useEffect(() => {
+    setCount(1);
+  }, [selected, setCount]);
+  
+  // TODO :: count 제한하여 패칭 멈추는 동작 필요
+  const willFetch = useCallback(() => getReviews(selected, count), [selected, count]);
+  const isInitialFetching = count === 1;
+  const state = useStackedFetchBase(willFetch, isInitialFetching);
+
   return { state, ref };
 };
 

--- a/src/views/ReviewPage/hooks/useFetch.ts
+++ b/src/views/ReviewPage/hooks/useFetch.ts
@@ -11,8 +11,10 @@ const useFetch = (selected: TAB) => {
 
   // initialize
   useEffect(() => {
-    setCount(1);
-    setCanGetMoreReviews();
+    return () => {
+      setCount(1);
+      setCanGetMoreReviews();
+    };
   }, [selected, setCount, setCanGetMoreReviews]);
 
   const willFetch = useCallback(

--- a/src/views/ReviewPage/hooks/useFetch.ts
+++ b/src/views/ReviewPage/hooks/useFetch.ts
@@ -7,17 +7,17 @@ import useInfiniteScroll from './useInfiniteScroll';
 
 const useFetch = (selected: TAB) => {
   const { ref, count, setCount } = useInfiniteScroll();
-  const [canGetMoreReviews, setIsStartToGetReviews, setIsEndToGetReviews] = useBooleanState(true);
+  const [canGetMoreReviews, setCanGetMoreReviews, setCanNotGetMoreReviews] = useBooleanState(true);
 
   // initialize
   useEffect(() => {
     setCount(1);
-    setIsStartToGetReviews();
-  }, [selected, setCount, setIsStartToGetReviews]);
+    setCanGetMoreReviews();
+  }, [selected, setCount, setCanGetMoreReviews]);
 
   const willFetch = useCallback(
-    () => getReviews(selected, count, setIsStartToGetReviews, setIsEndToGetReviews),
-    [selected, count, setIsStartToGetReviews, setIsEndToGetReviews],
+    () => getReviews(selected, count, setCanGetMoreReviews, setCanNotGetMoreReviews),
+    [selected, count, setCanGetMoreReviews, setCanNotGetMoreReviews],
   );
   const state = useStackedFetchBase(willFetch, count === 1);
 

--- a/src/views/ReviewPage/hooks/useFetch.ts
+++ b/src/views/ReviewPage/hooks/useFetch.ts
@@ -1,22 +1,27 @@
 import { useCallback, useEffect } from 'react';
+import useBooleanState from '@src/hooks/useBooleanState';
+import useStackedFetchBase from '@src/hooks/useStackedFetchBase';
 import { getReviews } from '@src/lib/review';
 import { TAB } from '../types';
 import useInfiniteScroll from './useInfiniteScroll';
-import useStackedFetchBase from '@src/hooks/useStackedFetchBase';
 
 const useFetch = (selected: TAB) => {
   const { ref, count, setCount } = useInfiniteScroll();
-  
+  const [canGetMoreReviews, setIsStartToGetReviews, setIsEndToGetReviews] = useBooleanState(true);
+
+  // initialize
   useEffect(() => {
     setCount(1);
-  }, [selected, setCount]);
-  
-  // TODO :: count 제한하여 패칭 멈추는 동작 필요
-  const willFetch = useCallback(() => getReviews(selected, count), [selected, count]);
-  const isInitialFetching = count === 1;
-  const state = useStackedFetchBase(willFetch, isInitialFetching);
+    setIsStartToGetReviews();
+  }, [selected, setCount, setIsStartToGetReviews]);
 
-  return { state, ref };
+  const willFetch = useCallback(
+    () => getReviews(selected, count, setIsStartToGetReviews, setIsEndToGetReviews),
+    [selected, count, setIsStartToGetReviews, setIsEndToGetReviews],
+  );
+  const state = useStackedFetchBase(willFetch, count === 1);
+
+  return { state, ref, canGetMoreReviews };
 };
 
 export default useFetch;

--- a/src/views/ReviewPage/hooks/useInfiniteScroll.ts
+++ b/src/views/ReviewPage/hooks/useInfiniteScroll.ts
@@ -1,0 +1,17 @@
+import useIntersectionObserver from '@src/hooks/useIntersectionObserver';
+import { useState } from 'react';
+
+// TODO :: 프로필 훅과 연동
+export default function useInfiniteScroll() {
+  const [count, setCount] = useState(1);
+
+  const ref = useIntersectionObserver(
+    async (entry, observer) => {
+      setCount(prevCount => prevCount + 1);
+      observer.unobserve(entry.target);
+    },
+    { threshold: 0.25, rootMargin: '80px' },
+  );
+
+  return { ref, count };
+}

--- a/src/views/ReviewPage/hooks/useInfiniteScroll.ts
+++ b/src/views/ReviewPage/hooks/useInfiniteScroll.ts
@@ -10,7 +10,7 @@ export default function useInfiniteScroll() {
       setCount(prevCount => prevCount + 1);
       observer.unobserve(entry.target);
     },
-    { threshold: 0.25, rootMargin: '80px' },
+    { rootMargin: '80px' },
   );
 
   return { ref, count };

--- a/src/views/ReviewPage/hooks/useInfiniteScroll.ts
+++ b/src/views/ReviewPage/hooks/useInfiniteScroll.ts
@@ -13,5 +13,5 @@ export default function useInfiniteScroll() {
     { rootMargin: '80px' },
   );
 
-  return { ref, count };
+  return { ref, count, setCount };
 }

--- a/src/views/ReviewPage/hooks/useInfiniteScroll.ts
+++ b/src/views/ReviewPage/hooks/useInfiniteScroll.ts
@@ -1,7 +1,6 @@
 import useIntersectionObserver from '@src/hooks/useIntersectionObserver';
 import { useState } from 'react';
 
-// TODO :: 프로필 훅과 연동
 export default function useInfiniteScroll() {
   const [count, setCount] = useState(1);
 


### PR DESCRIPTION
## Summary
- 프로필의 훅과 연동할 수 있는 것(`useIntersectionObserver`)은 두고, 변형되는 것은 새로 선언하였어요(`useInfiniteScroll`)
- `useFetchBase`에서 변형하여, 계속해서 쌓이는 데이터를 구성하기 위해 `useStackedFetchBase` 훅을 새로 선언하였어요
- 스크롤 로딩 뷰는 프로필 페이지의 스피너를 따와서 구성하였습니다!

#### 미완성
- [x] key 값에 index를 추가하여 구성하였어요. 이는 서버측의 데이터에서 중복 데이터가 계속 넘어와서 그렇고, 슬랙으로 확인 요청 남겼습니다!
- [x] selected Tab 에 따라서 쌓였던 데이터를 초기화하는 과정이 필요해서, 구현하고 있어요. ~의존성을 깔끔하게 분리하는 게 어렵네요 :((... (현재는 `willFetch`에서 pageNo가 1임을 알려주고, `useStackedFetchBase`에서 달리 구성하는 쪽으로 짜고 있씁니다)~

## Screenshot
https://user-images.githubusercontent.com/47105088/228190775-be0d1b61-0164-47c4-ab48-c0ae2867397c.mp4


## Comment
중간 리뷰 환영합니다 !~