### PR TITLE
feat: About 페이지의 핵심 가치 섹션 구현

### DIFF
--- a/src/components/common/Flex/index.tsx
+++ b/src/components/common/Flex/index.tsx
@@ -1,0 +1,78 @@
+import React, { useMemo } from 'react';
+import { useIsDesktop, useIsMobile, useIsTablet } from '@src/hooks/useDevice';
+
+type Responsive<T> = { mobile: T; tablet: T; desktop: T };
+type SingleOrResponsive<T> = T | Responsive<T>;
+
+type FlexProps = {
+  dir: SingleOrResponsive<React.CSSProperties['flexDirection']>;
+  gap: SingleOrResponsive<React.CSSProperties['gap']>;
+  style?: React.CSSProperties;
+};
+
+function isResponsiveProp<T>(value: SingleOrResponsive<T>): value is Responsive<T> {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    'mobile' in value &&
+    'tablet' in value &&
+    'desktop' in value
+  );
+}
+
+function parseProp<T>(prop: SingleOrResponsive<T>): Responsive<T> {
+  if (isResponsiveProp(prop)) {
+    return prop;
+  }
+  return { mobile: prop, tablet: prop, desktop: prop };
+}
+
+const Flex = ({ dir, gap, style, children }: React.PropsWithChildren<FlexProps>) => {
+  const isDesktop = useIsDesktop('1200px');
+  const isTablet = useIsTablet('766px', '1199.9px');
+  const isMobile = useIsMobile('765.9px');
+  const parsedGap = useMemo(() => parseProp(gap), [gap]);
+  const parsedFlexDirection = useMemo(() => parseProp(dir), [dir]);
+  console.log({ style });
+
+  const baseCssProps = useMemo(() => ({ ...style, display: 'flex' }), [style]);
+  if (isDesktop)
+    return (
+      <div
+        style={{
+          ...baseCssProps,
+          gap: parsedGap.desktop,
+          flexDirection: parsedFlexDirection.desktop,
+        }}
+      >
+        {children}
+      </div>
+    );
+  if (isTablet)
+    return (
+      <div
+        style={{
+          ...baseCssProps,
+          gap: parsedGap.tablet,
+          flexDirection: parsedFlexDirection.tablet,
+        }}
+      >
+        {children}
+      </div>
+    );
+  if (isMobile)
+    return (
+      <div
+        style={{
+          ...baseCssProps,
+          gap: parsedGap.mobile,
+          flexDirection: parsedFlexDirection.mobile,
+        }}
+      >
+        {children}
+      </div>
+    );
+  return <div style={baseCssProps}>{children}</div>;
+};
+
+export default Flex;

--- a/src/components/common/Flex/index.tsx
+++ b/src/components/common/Flex/index.tsx
@@ -1,5 +1,5 @@
+import styled from '@emotion/styled';
 import React, { useMemo } from 'react';
-import { useIsDesktop, useIsMobile, useIsTablet } from '@src/hooks/useDevice';
 
 type Responsive<T> = { mobile: T; tablet: T; desktop: T };
 type SingleOrResponsive<T> = T | Responsive<T>;
@@ -27,52 +27,48 @@ function parseProp<T>(prop: SingleOrResponsive<T>): Responsive<T> {
   return { mobile: prop, tablet: prop, desktop: prop };
 }
 
+const cssGapToString = (gap: React.CSSProperties['gap']): string | undefined => {
+  if (typeof gap === 'number') return `${gap}px`;
+  if (!gap) return '0px';
+  return gap;
+};
+
 const Flex = ({ dir, gap, style, children }: React.PropsWithChildren<FlexProps>) => {
-  const isDesktop = useIsDesktop('1200px');
-  const isTablet = useIsTablet('766px', '1199.9px');
-  const isMobile = useIsMobile('765.9px');
   const parsedGap = useMemo(() => parseProp(gap), [gap]);
   const parsedFlexDirection = useMemo(() => parseProp(dir), [dir]);
 
-  const baseCssProps = useMemo(() => ({ ...style, display: 'flex' }), [style]);
+  const baseCssProps = useMemo(() => ({ ...style }), [style]);
 
-  if (isDesktop)
-    return (
-      <div
-        style={{
-          ...baseCssProps,
-          gap: parsedGap.desktop,
-          flexDirection: parsedFlexDirection.desktop,
-        }}
-      >
-        {children}
-      </div>
-    );
-  if (isTablet)
-    return (
-      <div
-        style={{
-          ...baseCssProps,
-          gap: parsedGap.tablet,
-          flexDirection: parsedFlexDirection.tablet,
-        }}
-      >
-        {children}
-      </div>
-    );
-  if (isMobile)
-    return (
-      <div
-        style={{
-          ...baseCssProps,
-          gap: parsedGap.mobile,
-          flexDirection: parsedFlexDirection.mobile,
-        }}
-      >
-        {children}
-      </div>
-    );
-  return <div style={baseCssProps}>{children}</div>;
+  return (
+    <Div
+      style={{
+        ...baseCssProps,
+      }}
+      gap={parsedGap}
+      flexDirection={parsedFlexDirection}
+    >
+      {children}
+    </Div>
+  );
 };
+
+const Div = styled.div<{
+  gap: Responsive<React.CSSProperties['gap']>;
+  flexDirection: Responsive<React.CSSProperties['flexDirection']>;
+}>`
+  display: flex;
+  gap: ${(props) => cssGapToString(props.gap.desktop)};
+  flex-direction: ${(props) => props.flexDirection.desktop};
+
+  @media (max-width: 1199px) {
+    gap: ${(props) => cssGapToString(props.gap.tablet)};
+    flex-direction: ${(props) => props.flexDirection.tablet};
+  }
+
+  @media (max-width: 765.9px) {
+    gap: ${(props) => cssGapToString(props.gap.mobile)};
+    flex-direction: ${(props) => props.flexDirection.mobile};
+  }
+`;
 
 export default Flex;

--- a/src/components/common/Flex/index.tsx
+++ b/src/components/common/Flex/index.tsx
@@ -33,9 +33,9 @@ const Flex = ({ dir, gap, style, children }: React.PropsWithChildren<FlexProps>)
   const isMobile = useIsMobile('765.9px');
   const parsedGap = useMemo(() => parseProp(gap), [gap]);
   const parsedFlexDirection = useMemo(() => parseProp(dir), [dir]);
-  console.log({ style });
 
   const baseCssProps = useMemo(() => ({ ...style, display: 'flex' }), [style]);
+
   if (isDesktop)
     return (
       <div

--- a/src/lib/api/mock/about.ts
+++ b/src/lib/api/mock/about.ts
@@ -14,18 +14,18 @@ const getAboutInfo = async (generation: number): Promise<GetAboutInfoResponse> =
         '32기 Go SOPT는 협업을 중시하는 멤버들과 함께 나아가며\n끊임없이 실천하는 태도를 지향합니다.',
       eachValues: [
         {
-          title: '이',
-          description: '이주함의 0번 인덱스 값인\n이 입니다.',
+          title: 'Protect',
+          description: '몸살으로부터\n주함을 지킵니다.',
           src: SRC,
         },
         {
-          title: '주',
-          description: '이주함의 1번 인덱스 값인\n주 입니다.',
+          title: 'Health',
+          description: '주함 항상\n건강해야 합니다.',
           src: SRC,
         },
         {
-          title: '함',
-          description: '이주함의 2번 인덱스 값인\n함 입니다.',
+          title: 'Retrieve',
+          description: '푹 쉬고 건강을\n되찾습니다.',
           src: SRC,
         },
       ],

--- a/src/views/AboutPage/AboutPage.tsx
+++ b/src/views/AboutPage/AboutPage.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import { Footer, Header, Layout } from '@src/components';
 import Banner from './components/Banner';
+import CoreValueSection from './components/CoreValue/Section';
 import useFetch from './hooks/useFetch';
 
 const AboutPage = () => {
@@ -16,6 +17,10 @@ const AboutPage = () => {
             generation={state.data.aboutInfo.generation}
             title={state.data.aboutInfo.title}
           />
+          <CoreValueSection
+            mainDescription={state.data.aboutInfo.coreValue.mainDescription}
+            coreValues={state.data.aboutInfo.coreValue.eachValues}
+          />
         </Root>
       )}
       <Footer />
@@ -28,6 +33,7 @@ export default AboutPage;
 const Root = styled.main`
   display: flex;
   flex-direction: column;
+  gap: 180px;
   width: 1200px;
   min-height: 100vh;
   margin: 0 auto;
@@ -35,9 +41,11 @@ const Root = styled.main`
   /* 태블릿 뷰 */
   @media (max-width: 1199px) and (min-width: 766px) {
     width: 700px;
+    gap: 140px;
   }
   /* 모바일 뷰 */
   @media (max-width: 765.9px) {
     width: 360px;
+    gap: 80px;
   }
 `;

--- a/src/views/AboutPage/components/CoreValue/Item/index.tsx
+++ b/src/views/AboutPage/components/CoreValue/Item/index.tsx
@@ -1,0 +1,61 @@
+import { useMemo, useState } from 'react';
+import Flex from '@src/components/common/Flex';
+import { useIsDesktop, useIsMobile, useIsTablet } from '@src/hooks/useDevice';
+import { CoreValueType } from '@src/lib/types/about';
+import * as St from './style';
+
+type CoreValueProps = {
+  coreValue: CoreValueType;
+};
+
+const getBackgroundBlurStrength = (
+  isDesktop: boolean,
+  isTablet: boolean,
+  isMobile: boolean,
+  isHovered: boolean,
+): St.BlurStrengthType => {
+  if (isTablet) return 'small';
+  if (isMobile) return 'medium';
+  if (isDesktop) {
+    if (isHovered) return 'strong';
+    return 'none';
+  }
+  return 'none';
+};
+
+const CoreValueItem = ({ coreValue }: CoreValueProps) => {
+  const isDesktop = useIsDesktop('1200px');
+  const isTablet = useIsTablet('766px', '1199.9px');
+  const isMobile = useIsMobile('765.9px');
+  const [isHovered, setIsHovered] = useState(false);
+
+  const blurStrength = useMemo(
+    () => getBackgroundBlurStrength(isDesktop, isTablet, isMobile, isHovered),
+    [isDesktop, isTablet, isMobile, isHovered],
+  );
+
+  return (
+    <St.ItemContainer
+      src={coreValue.src}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
+      <St.BackgroundBlur strength={blurStrength} />
+      <Flex
+        dir="column"
+        gap={{ desktop: 16, tablet: 8, mobile: 8 }}
+        style={{
+          position: 'absolute',
+          top: '50%',
+          left: '50%',
+          transform: 'translate(-50%, -50%)',
+        }}
+      >
+        <St.CoreValue>{coreValue.title}</St.CoreValue>
+        <St.CoreValueSub isHovered={isHovered}>{coreValue.description}</St.CoreValueSub>
+      </Flex>
+    </St.ItemContainer>
+  );
+};
+
+export default CoreValueItem;

--- a/src/views/AboutPage/components/CoreValue/Item/style.ts
+++ b/src/views/AboutPage/components/CoreValue/Item/style.ts
@@ -1,0 +1,75 @@
+import styled from '@emotion/styled';
+
+export const ItemContainer = styled.div<{ src: string }>`
+  color: white;
+  position: relative;
+  width: 380px;
+  height: 380px;
+  background-image: url(${({ src }) => src});
+  background-size: 100%;
+  cursor: default;
+
+  /* 태블릿 뷰 */
+  @media (max-width: 1199px) and (min-width: 766px) {
+    height: 209px;
+  }
+  /* 모바일 뷰 */
+  @media (max-width: 765.9px) {
+    height: 330px;
+  }
+`;
+
+export type BlurStrengthType = 'none' | 'small' | 'medium' | 'strong';
+const backgroundBlur: Record<BlurStrengthType, number> = {
+  none: 0,
+  small: 10,
+  medium: 20,
+  strong: 60,
+};
+
+export const BackgroundBlur = styled.div<{ strength: BlurStrengthType }>`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, ${({ strength }) => backgroundBlur[strength]}%);
+  transition: 0.3s;
+`;
+
+export const CoreValue = styled.div`
+  text-align: center;
+  font-weight: 700;
+  font-size: 60px;
+  letter-spacing: -1%;
+
+  /* 태블릿 뷰 */
+  @media (max-width: 1199px) and (min-width: 766px) {
+    font-size: 24px;
+  }
+  /* 모바일 뷰 */
+  @media (max-width: 765.9px) {
+    font-size: 24px;
+    line-height: 33px;
+  }
+`;
+
+export const CoreValueSub = styled.div<{ isHovered: boolean }>`
+  text-align: center;
+  font-size: 28px;
+  line-height: 150%;
+  letter-spacing: -1%;
+  color: rgba(#ffffff, 70%);
+  transition: 0.3s;
+  white-space: pre-line;
+
+  /* 데스크탑 뷰 */
+  @media (min-width: 1200px) {
+    ${({ isHovered }) => !isHovered && 'display: none'}
+  }
+
+  /* 태블릿, 모바일 뷰 */
+  @media (max-width: 1199px) {
+    font-size: 16px;
+  }
+`;

--- a/src/views/AboutPage/components/CoreValue/List/index.tsx
+++ b/src/views/AboutPage/components/CoreValue/List/index.tsx
@@ -1,0 +1,22 @@
+import Flex from '@src/components/common/Flex';
+import { CoreValueType } from '@src/lib/types/about';
+import CoreValueItem from '../Item';
+
+type CoreValueListProps = {
+  coreValues: CoreValueType[];
+};
+
+const CoreValueList = ({ coreValues }: CoreValueListProps) => {
+  return (
+    <Flex
+      dir={{ mobile: 'column', tablet: 'row', desktop: 'row' }}
+      gap={{ mobile: 20, tablet: 20, desktop: 30 }}
+    >
+      {coreValues.map((coreValue) => (
+        <CoreValueItem coreValue={coreValue} key={coreValue.title} />
+      ))}
+    </Flex>
+  );
+};
+
+export default CoreValueList;

--- a/src/views/AboutPage/components/CoreValue/Section/index.tsx
+++ b/src/views/AboutPage/components/CoreValue/Section/index.tsx
@@ -1,0 +1,28 @@
+import Flex from '@src/components/common/Flex';
+import { CoreValueType } from '@src/lib/types/about';
+import SectionDescription from '../../common/SectionDescription';
+import SectionTitle from '../../common/SectionTitle';
+import CoreValueList from '../List';
+import * as St from './style';
+
+type CoreValueSectionProps = {
+  mainDescription: string;
+  coreValues: CoreValueType[];
+};
+
+const CoreValueSection = ({ mainDescription, coreValues }: CoreValueSectionProps) => {
+  return (
+    <St.CoreValueSectionWrapper>
+      <St.MarginBanner />
+      <Flex dir="column" gap={{ mobile: 32, tablet: 48, desktop: 48 }}>
+        <Flex dir="column" gap={{ mobile: 8, tablet: 20, desktop: 28 }}>
+          <SectionTitle>핵심 가치</SectionTitle>
+          <SectionDescription>{mainDescription}</SectionDescription>
+        </Flex>
+        <CoreValueList coreValues={coreValues} />
+      </Flex>
+    </St.CoreValueSectionWrapper>
+  );
+};
+
+export default CoreValueSection;

--- a/src/views/AboutPage/components/CoreValue/Section/style.ts
+++ b/src/views/AboutPage/components/CoreValue/Section/style.ts
@@ -1,0 +1,27 @@
+import styled from '@emotion/styled';
+
+export const MarginBanner = styled.div`
+  height: 630px;
+
+  /* 태블릿 뷰 */
+  @media (max-width: 1199px) and (min-width: 766px) {
+    height: 380px;
+  }
+  /* 모바일 뷰 */
+  @media (max-width: 765.9px) {
+    height: 178px;
+  }
+`;
+
+export const CoreValueSectionWrapper = styled.div`
+  padding-top: 136px;
+
+  /* 태블릿 뷰 */
+  @media (max-width: 1199px) and (min-width: 766px) {
+    padding-top: 92px;
+  }
+  /* 모바일 뷰 */
+  @media (max-width: 765.9px) {
+    padding-top: 46px;
+  }
+`;

--- a/src/views/AboutPage/components/common/SectionDescription/index.tsx
+++ b/src/views/AboutPage/components/common/SectionDescription/index.tsx
@@ -1,0 +1,27 @@
+import styled from '@emotion/styled';
+import { ReactNode } from 'react';
+
+const SectionDescription = ({ children }: { children: ReactNode }) => {
+  return <Div>{children}</Div>;
+};
+
+const Div = styled.div`
+  font-size: 28px;
+  line-height: 150%;
+  letter-spacing: 0%;
+  color: #ffffff;
+  white-space: pre-line;
+  /* 태블릿 뷰 */
+  @media (max-width: 1199px) and (min-width: 766px) {
+    font-size: 18px;
+    line-height: 26px;
+    text-align: center;
+  }
+  /* 모바일 뷰 */
+  @media (max-width: 765.9px) {
+    font-size: 16px;
+    line-height: 150%;
+  }
+`;
+
+export default SectionDescription;

--- a/src/views/AboutPage/components/common/SectionTitle/index.tsx
+++ b/src/views/AboutPage/components/common/SectionTitle/index.tsx
@@ -1,0 +1,27 @@
+import styled from '@emotion/styled';
+import { ReactNode } from 'react';
+
+const SectionTitle = ({ children }: { children: ReactNode }) => {
+  return <H1>{children}</H1>;
+};
+
+const H1 = styled.h1`
+  font-size: 45px;
+  line-height: 60px;
+  letter-spacing: -1%;
+  font-weight: 700;
+  /* 태블릿 뷰 */
+  @media (max-width: 1199px) and (min-width: 766px) {
+    font-size: 28px;
+    line-height: 100%;
+    text-align: center;
+  }
+  /* 모바일 뷰 */
+  @media (max-width: 765.9px) {
+    font-size: 18px;
+    line-height: 150%;
+    text-align: center;
+  }
+`;
+
+export default SectionTitle;


### PR DESCRIPTION
## Summary
About 페이지의 핵심 가치 섹션을 구현합니다.

## Linked Issue
* #111 

## Screenshot
![screenshot](https://user-images.githubusercontent.com/48249505/235413391-e0c14dd4-aff6-43b1-965f-ce528b11a013.gif)

## Comment

추가적인 사항은 코멘트로 작성하겠습니다!

* Flex 라는 컴포넌트를 만들어서, Flex 관련해서 반복 선언하는 부분을 더 직관적으로 옮겨보려는 시도를 하였습니다. 그리고 (개인적으로) 다른 div 간에 마진을 주는 것보다 flex로 싸고 gap을 주는 걸 좋아하는데요, (-) 돔트리가 더 깊어진다 (+) 프로그래머가 보고 수정하기 편하다 라고 생각합니다.. 당신의 의견은 어떠십니까?
* 각 섹션의 제목은 모두 서식이 같아서 `SectionTitle` 안에다가 넣으면 될 것 같습니다!