### PR TITLE
chore: split about api and members api

### DIFF
--- a/src/lib/api/mock/about.ts
+++ b/src/lib/api/mock/about.ts
@@ -1,4 +1,4 @@
-import { GetAboutInfoResponse } from '@src/lib/types/about';
+import { GetAboutInfoResponse, GetMembersInfoResponse } from '@src/lib/types/about';
 import { Part } from '@src/lib/types/universal';
 
 const BANNER_SRC = 'https://i.ibb.co/84ybMKQ/image-76.png';
@@ -43,17 +43,23 @@ const getAboutInfo = async (generation: number): Promise<GetAboutInfoResponse> =
       projectCount: 24,
       studyCount: 300,
     },
-    members: Array.from({ length: 12 }, () =>
-      [Part.PLAN, Part.ANDROID, Part.DESIGN, Part.IOS, Part.SERVER, Part.WEB].map((part) => ({
+  },
+});
+
+const getMemberInfo = async (part?: Part): Promise<GetMembersInfoResponse> => ({
+  members: Array.from({ length: 12 }, () =>
+    (part ? [part] : [Part.PLAN, Part.ANDROID, Part.DESIGN, Part.IOS, Part.SERVER, Part.WEB]).map(
+      (part) => ({
         name: '이주함',
         description: `2023년 현존하는 최고의 ${part}`,
         part,
         src: SRC,
-      })),
-    ).flat(),
-  },
+      }),
+    ),
+  ).flat(),
 });
 
 export const mockAboutAPI = {
   getAboutInfo,
+  getMemberInfo,
 };

--- a/src/lib/types/about.ts
+++ b/src/lib/types/about.ts
@@ -27,6 +27,9 @@ export interface AboutInfoType {
     projectCount: number;
     studyCount: number;
   };
+}
+
+export interface GetMembersInfoResponse {
   members: MemberType[];
 }
 
@@ -36,4 +39,5 @@ export interface GetAboutInfoResponse {
 
 export interface AboutAPI {
   getAboutInfo(generation: number): Promise<GetAboutInfoResponse>;
+  getMemberInfo(part?: Part): Promise<GetMembersInfoResponse>;
 }


### PR DESCRIPTION
## Summary
about API와 members API를 분리했습니다.

## Comment
API가 두 개 생긴 것입니다!

이 API를 호출하는 건 그 섹션 내에서 할 지 AboutPage.tsx에서 할 지 고민해 보아야 할 것 같습니다..!! 물론 나중에는 한번에 할 것이지만요

```ts
const getMemberInfo = async (part?: Part): Promise<GetMembersInfoResponse>
```