### PR TITLE
feat: About 탭 커리큘럼 섹션 구현

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -9,6 +9,7 @@ const nextConfig = {
       'sopt-makers.s3.ap-northeast-2.amazonaws.com',
       's3.ap-northeast-2.amazonaws.com',
       'user-images.githubusercontent.com',
+      'avatars.githubusercontent.com',
       'i.ibb.co',
     ],
   },

--- a/src/lib/api/mock/about.ts
+++ b/src/lib/api/mock/about.ts
@@ -3,10 +3,11 @@ import { Part } from '@src/lib/types/universal';
 
 const BANNER_SRC = 'https://i.ibb.co/84ybMKQ/image-76.png';
 const SRC = 'https://avatars.githubusercontent.com/u/47105088?v=4';
+const SRC_MAIN = 'https://avatars.githubusercontent.com/u/48249505?v=4';
 
-const getAboutInfo = async (generation: number): Promise<GetAboutInfoResponse> => ({
+const getAboutInfo = async (): Promise<GetAboutInfoResponse> => ({
   aboutInfo: {
-    generation,
+    generation: 32,
     title: 'GO SOPT',
     bannerImage: BANNER_SRC,
     coreValue: {
@@ -31,11 +32,11 @@ const getAboutInfo = async (generation: number): Promise<GetAboutInfoResponse> =
       ],
     },
     curriculums: {
-      [Part.PLAN]: SRC,
-      [Part.DESIGN]: SRC,
-      [Part.ANDROID]: SRC,
-      [Part.IOS]: SRC,
-      [Part.SERVER]: SRC,
+      [Part.PLAN]: SRC_MAIN,
+      [Part.DESIGN]: BANNER_SRC,
+      [Part.ANDROID]: BANNER_SRC,
+      [Part.IOS]: BANNER_SRC,
+      [Part.SERVER]: BANNER_SRC,
       [Part.WEB]: SRC,
     },
     records: {

--- a/src/lib/api/remote/review.ts
+++ b/src/lib/api/remote/review.ts
@@ -1,21 +1,16 @@
+import { ExtraPart, PartExtraType } from '@src/lib/types/universal';
 import { BASE_URL, DEFAULT_TIMEOUT } from '@src/utils/const/client';
 import axios from 'axios';
 import qs from 'qs';
-import {
-  GetReviewsResponse,
-  GetSampleReviewsResponse,
-  ReviewAPI,
-  ReviewTabExtraType,
-  ReviewTabType,
-} from '../../types/review';
+import { GetReviewsResponse, GetSampleReviewsResponse, ReviewAPI } from '../../types/review';
 
 const client = axios.create({
   baseURL: BASE_URL,
   timeout: DEFAULT_TIMEOUT,
 });
 
-const getReviews = async (tab: ReviewTabType, pageNo = 1): Promise<GetReviewsResponse> => {
-  const partParameter = tab === ReviewTabExtraType.ALL ? {} : { part: tab };
+const getReviews = async (tab: ExtraPart, pageNo = 1): Promise<GetReviewsResponse> => {
+  const partParameter = tab === PartExtraType.ALL ? {} : { part: tab };
   const pageParameter = { pageNo, limit: 6 };
   const parameter = qs.stringify({ ...partParameter, ...pageParameter });
 

--- a/src/lib/types/about.ts
+++ b/src/lib/types/about.ts
@@ -38,6 +38,6 @@ export interface GetAboutInfoResponse {
 }
 
 export interface AboutAPI {
-  getAboutInfo(generation: number): Promise<GetAboutInfoResponse>;
+  getAboutInfo(): Promise<GetAboutInfoResponse>;
   getMemberInfo(part?: Part): Promise<GetMembersInfoResponse>;
 }

--- a/src/lib/types/review.ts
+++ b/src/lib/types/review.ts
@@ -1,15 +1,4 @@
-import { Part } from './universal';
-
-export enum ReviewTabExtraType {
-  ALL = 'ALL',
-}
-
-export type ReviewTabType = ReviewTabExtraType | Part;
-
-export type TabType = {
-  value: ReviewTabType;
-  label: string;
-};
+import { ExtraPart } from './universal';
 
 export type ReviewType = {
   id: number;
@@ -32,6 +21,6 @@ export type GetReviewsResponse = {
 };
 
 export interface ReviewAPI {
-  getReviews(tab: ReviewTabType, page: number): Promise<GetReviewsResponse>;
+  getReviews(tab: ExtraPart, page: number): Promise<GetReviewsResponse>;
   getSampleReviews(): Promise<GetSampleReviewsResponse>;
 }

--- a/src/lib/types/universal.ts
+++ b/src/lib/types/universal.ts
@@ -17,18 +17,16 @@ export enum Part {
   SERVER = 'SERVER',
 }
 
-export type TabType = {
-  value: Part;
-  label: string;
-};
-
 export enum PartExtraType {
   ALL = 'ALL',
 }
 
 export type ExtraPart = PartExtraType | Part;
 
-export type ExtraTabType = {
-  value: ExtraPart;
+type TapTypeOption<T> = {
+  value: T;
   label: string;
 };
+
+export type TabType = TapTypeOption<Part>;
+export type ExtraTabType = TapTypeOption<ExtraPart>;

--- a/src/lib/types/universal.ts
+++ b/src/lib/types/universal.ts
@@ -16,3 +16,19 @@ export enum Part {
   WEB = 'WEB',
   SERVER = 'SERVER',
 }
+
+export type TabType = {
+  value: Part;
+  label: string;
+};
+
+export enum PartExtraType {
+  ALL = 'ALL',
+}
+
+export type ExtraPart = PartExtraType | Part;
+
+export type ExtraTabType = {
+  value: ExtraPart;
+  label: string;
+};

--- a/src/views/AboutPage/AboutPage.tsx
+++ b/src/views/AboutPage/AboutPage.tsx
@@ -22,7 +22,7 @@ const AboutPage = () => {
             mainDescription={state.data.aboutInfo.coreValue.mainDescription}
             coreValues={state.data.aboutInfo.coreValue.eachValues}
           />
-          <CirriculumSection />
+          <CirriculumSection cirriculums={state.data.aboutInfo.curriculums} />
         </Root>
       )}
       <Footer />

--- a/src/views/AboutPage/AboutPage.tsx
+++ b/src/views/AboutPage/AboutPage.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import { Footer, Header, Layout } from '@src/components';
 import Banner from './components/Banner';
+import CirriculumSection from './components/Cirriculum/Section';
 import CoreValueSection from './components/CoreValue/Section';
 import useFetch from './hooks/useFetch';
 
@@ -21,6 +22,7 @@ const AboutPage = () => {
             mainDescription={state.data.aboutInfo.coreValue.mainDescription}
             coreValues={state.data.aboutInfo.coreValue.eachValues}
           />
+          <CirriculumSection />
         </Root>
       )}
       <Footer />

--- a/src/views/AboutPage/AboutPage.tsx
+++ b/src/views/AboutPage/AboutPage.tsx
@@ -42,12 +42,12 @@ const Root = styled.main`
 
   /* 태블릿 뷰 */
   @media (max-width: 1199px) and (min-width: 766px) {
-    width: 700px;
+    width: 667px;
     gap: 140px;
   }
   /* 모바일 뷰 */
   @media (max-width: 765.9px) {
-    width: 360px;
+    width: 332px;
     gap: 80px;
   }
 `;

--- a/src/views/AboutPage/components/Cirriculum/Content/index.tsx
+++ b/src/views/AboutPage/components/Cirriculum/Content/index.tsx
@@ -14,7 +14,7 @@ const CirriculumContent = ({ cirriculums }: CirriculumContentProps) => {
 
   return (
     <Flex dir="column" gap={{ mobile: 18, tablet: 24, desktop: 48 }}>
-      <TabBar onTabClick={setCurrentPart} selectedTab={currentPart} />
+      <TabBar onTabClick={setCurrentPart} selectedTab={currentPart} includesExtra={false} />
       <St.ImageWrapper>
         <Image
           src={cirriculums[currentPart]}

--- a/src/views/AboutPage/components/Cirriculum/Content/index.tsx
+++ b/src/views/AboutPage/components/Cirriculum/Content/index.tsx
@@ -1,0 +1,30 @@
+import Image from 'next/image';
+import { useState } from 'react';
+import Flex from '@src/components/common/Flex';
+import { Part } from '@src/lib/types/universal';
+import TabBar from '../../common/TabBar';
+import * as St from './style';
+
+type CirriculumContentProps = {
+  cirriculums: Record<Part, string>;
+};
+
+const CirriculumContent = ({ cirriculums }: CirriculumContentProps) => {
+  const [currentPart, setCurrentPart] = useState(Part.PLAN);
+
+  return (
+    <Flex dir="column" gap={{ mobile: 18, tablet: 24, desktop: 48 }}>
+      <TabBar onTabClick={setCurrentPart} selectedTab={currentPart} />
+      <St.ImageWrapper>
+        <Image
+          src={cirriculums[currentPart]}
+          alt={currentPart}
+          fill
+          style={{ objectFit: 'contain' }}
+        />
+      </St.ImageWrapper>
+    </Flex>
+  );
+};
+
+export default CirriculumContent;

--- a/src/views/AboutPage/components/Cirriculum/Content/style.ts
+++ b/src/views/AboutPage/components/Cirriculum/Content/style.ts
@@ -1,0 +1,15 @@
+import styled from '@emotion/styled';
+
+export const ImageWrapper = styled.div`
+  position: relative;
+  width: 100%;
+  height: 600px;
+  /* 태블릿 뷰 */
+  @media (max-width: 1199px) and (min-width: 766px) {
+    height: 334px;
+  }
+  /* 모바일 뷰 */
+  @media (max-width: 765.9px) {
+    height: 192px;
+  }
+`;

--- a/src/views/AboutPage/components/Cirriculum/Section/index.tsx
+++ b/src/views/AboutPage/components/Cirriculum/Section/index.tsx
@@ -1,6 +1,7 @@
 import Flex from '@src/components/common/Flex';
 import { Part } from '@src/lib/types/universal';
 import SectionTitle from '../../common/SectionTitle';
+import CirriculumContent from '../Content';
 
 type CirriculumSectionProps = {
   cirriculums: Record<Part, string>;
@@ -8,12 +9,9 @@ type CirriculumSectionProps = {
 
 const CirriculumSection = ({ cirriculums }: CirriculumSectionProps) => {
   return (
-    <Flex dir="column" gap={{ mobile: 60, tablet: 48, desktop: 24 }}>
-      <SectionTitle>모집 파트 & 커리큘럼</SectionTitle>;
-      <Flex dir="column" gap={{ mobile: 48, tablet: 24, desktop: 18 }}>
-        <div>탭</div>
-        <div>사진</div>
-      </Flex>
+    <Flex dir="column" gap={{ mobile: 24, tablet: 48, desktop: 60 }}>
+      <SectionTitle>모집 파트 & 커리큘럼</SectionTitle>
+      <CirriculumContent cirriculums={cirriculums} />
     </Flex>
   );
 };

--- a/src/views/AboutPage/components/Cirriculum/Section/index.tsx
+++ b/src/views/AboutPage/components/Cirriculum/Section/index.tsx
@@ -1,7 +1,12 @@
 import Flex from '@src/components/common/Flex';
+import { Part } from '@src/lib/types/universal';
 import SectionTitle from '../../common/SectionTitle';
 
-const CirriculumSection = () => {
+type CirriculumSectionProps = {
+  cirriculums: Record<Part, string>;
+};
+
+const CirriculumSection = ({ cirriculums }: CirriculumSectionProps) => {
   return (
     <Flex dir="column" gap={{ mobile: 60, tablet: 48, desktop: 24 }}>
       <SectionTitle>모집 파트 & 커리큘럼</SectionTitle>;

--- a/src/views/AboutPage/components/Cirriculum/Section/index.tsx
+++ b/src/views/AboutPage/components/Cirriculum/Section/index.tsx
@@ -1,0 +1,16 @@
+import Flex from '@src/components/common/Flex';
+import SectionTitle from '../../common/SectionTitle';
+
+const CirriculumSection = () => {
+  return (
+    <Flex dir="column" gap={{ mobile: 60, tablet: 48, desktop: 24 }}>
+      <SectionTitle>모집 파트 & 커리큘럼</SectionTitle>;
+      <Flex dir="column" gap={{ mobile: 48, tablet: 24, desktop: 18 }}>
+        <div>탭</div>
+        <div>사진</div>
+      </Flex>
+    </Flex>
+  );
+};
+
+export default CirriculumSection;

--- a/src/views/AboutPage/components/common/TabBar/index.tsx
+++ b/src/views/AboutPage/components/common/TabBar/index.tsx
@@ -1,22 +1,41 @@
-import { ExtraPart, ExtraTabType, Part } from '@src/lib/types/universal';
-import { TabType } from '@src/lib/types/universal';
-import { tabs } from '@src/views/AboutPage/constant/taps';
+import { ExtraPart, Part } from '@src/lib/types/universal';
+import { extraTabs, tabs } from '@src/views/AboutPage/constant/taps';
 import * as St from './style';
 
-type TabBarProps = {
+type TabBarPropsIncludedExtra = {
+  includesExtra: true;
   selectedTab: ExtraPart;
+  onTabClick(targetTab: ExtraPart): void;
+};
+type TabBarPropsNoExtra = {
+  includesExtra: false;
+  selectedTab: Part;
   onTabClick(targetTab: Part): void;
 };
+type TabBarProps = TabBarPropsIncludedExtra | TabBarPropsNoExtra;
 
-const TabBar = ({ onTabClick, selectedTab }: TabBarProps) => {
+const TabBar = ({ includesExtra, onTabClick, selectedTab }: TabBarProps) => {
+  if (includesExtra)
+    return (
+      <St.TabBar>
+        {extraTabs.map((tab) => (
+          <Tab
+            key={tab.value}
+            onClick={() => onTabClick(tab.value)}
+            label={tab.label}
+            selected={selectedTab === tab.value}
+          />
+        ))}
+      </St.TabBar>
+    );
+
   return (
     <St.TabBar>
-      {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-      {(tabs as any).slice(1).map((tab: TabType) => (
+      {tabs.map((tab) => (
         <Tab
           key={tab.value}
           onClick={() => onTabClick(tab.value)}
-          tab={tab}
+          label={tab.label}
           selected={selectedTab === tab.value}
         />
       ))}
@@ -26,13 +45,13 @@ const TabBar = ({ onTabClick, selectedTab }: TabBarProps) => {
 
 type TabProps = {
   onClick(): void;
-  tab: ExtraTabType;
+  label: string;
   selected: boolean;
 };
 
-const Tab = ({ onClick, tab, selected }: TabProps) => (
+const Tab = ({ onClick, label, selected }: TabProps) => (
   <St.Tab selected={selected} onClick={onClick}>
-    {tab.label}
+    {label}
   </St.Tab>
 );
 

--- a/src/views/AboutPage/components/common/TabBar/index.tsx
+++ b/src/views/AboutPage/components/common/TabBar/index.tsx
@@ -1,0 +1,39 @@
+import { ExtraPart, ExtraTabType, Part } from '@src/lib/types/universal';
+import { TabType } from '@src/lib/types/universal';
+import { tabs } from '@src/views/AboutPage/constant/taps';
+import * as St from './style';
+
+type TabBarProps = {
+  selectedTab: ExtraPart;
+  onTabClick(targetTab: Part): void;
+};
+
+const TabBar = ({ onTabClick, selectedTab }: TabBarProps) => {
+  return (
+    <St.TabBar>
+      {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+      {(tabs as any).slice(1).map((tab: TabType) => (
+        <Tab
+          key={tab.value}
+          onClick={() => onTabClick(tab.value)}
+          tab={tab}
+          selected={selectedTab === tab.value}
+        />
+      ))}
+    </St.TabBar>
+  );
+};
+
+type TabProps = {
+  onClick(): void;
+  tab: ExtraTabType;
+  selected: boolean;
+};
+
+const Tab = ({ onClick, tab, selected }: TabProps) => (
+  <St.Tab selected={selected} onClick={onClick}>
+    {tab.label}
+  </St.Tab>
+);
+
+export default TabBar;

--- a/src/views/AboutPage/components/common/TabBar/style.ts
+++ b/src/views/AboutPage/components/common/TabBar/style.ts
@@ -1,0 +1,58 @@
+import styled from '@emotion/styled';
+import { css } from '@emotion/react';
+
+export const TabBar = styled.ul`
+  width: 100%;
+  height: 68px;
+
+  display: flex;
+  justify-content: center;
+
+  font-size: 28px;
+  font-weight: 400;
+  letter-spacing: -0.01em;
+  color: rgba(255, 255, 255, 0.5);
+
+  /* 태블릿 뷰 */
+  @media (max-width: 1199px) and (min-width: 766px) {
+    height: 38px;
+    font-size: 18px;
+  }
+  /* 모바일 뷰 */
+  @media (max-width: 765.9px) {
+    min-height: 36px;
+    font-size: 12px;
+    font-weight: 500;
+    color: rgba(255, 255, 255, 0.6);
+
+    flex-wrap: wrap;
+    & > li {
+      min-width: 72px;
+      max-width: 72px;
+    }
+  }
+`;
+
+export const Tab = styled.li<{ selected: boolean }>`
+  flex: 1;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  cursor: pointer;
+  ${({ selected }) =>
+    selected &&
+    css`
+      font-weight: 700;
+      color: #ffffff;
+      border-bottom: 3px solid #ffffff;
+      /* 모바일 뷰 */
+      @media (max-width: 765.9px) {
+        font-weight: 500;
+        border-bottom: none;
+        background: rgba(255, 255, 255, 0.1);
+        border-radius: 10px;
+      }
+    `};
+`;

--- a/src/views/AboutPage/constant/taps.ts
+++ b/src/views/AboutPage/constant/taps.ts
@@ -1,6 +1,6 @@
-import { ExtraTabType, Part, PartExtraType } from '@src/lib/types/universal';
+import { ExtraTabType, Part, PartExtraType, TabType } from '@src/lib/types/universal';
 
-export const tabs: ExtraTabType[] = [
+export const extraTabs: ExtraTabType[] = [
   {
     value: PartExtraType.ALL,
     label: '전체',
@@ -30,3 +30,5 @@ export const tabs: ExtraTabType[] = [
     label: 'Server',
   },
 ];
+
+export const tabs = extraTabs.slice(1) as TabType[];

--- a/src/views/AboutPage/constant/taps.ts
+++ b/src/views/AboutPage/constant/taps.ts
@@ -1,0 +1,32 @@
+import { ExtraTabType, Part, PartExtraType } from '@src/lib/types/universal';
+
+export const tabs: ExtraTabType[] = [
+  {
+    value: PartExtraType.ALL,
+    label: '전체',
+  },
+  {
+    value: Part.PLAN,
+    label: '기획',
+  },
+  {
+    value: Part.DESIGN,
+    label: '디자인',
+  },
+  {
+    value: Part.ANDROID,
+    label: 'Android',
+  },
+  {
+    value: Part.IOS,
+    label: 'iOS',
+  },
+  {
+    value: Part.WEB,
+    label: 'Web',
+  },
+  {
+    value: Part.SERVER,
+    label: 'Server',
+  },
+];

--- a/src/views/AboutPage/hooks/useFetch.ts
+++ b/src/views/AboutPage/hooks/useFetch.ts
@@ -4,7 +4,7 @@ import { api } from '@src/lib/api';
 
 const useFetch = () => {
   const willFetch = useCallback(async () => {
-    const response = await api.aboutAPI.getAboutInfo(32);
+    const response = await api.aboutAPI.getAboutInfo();
     return response;
   }, []);
   const state = useFetchBase(willFetch);

--- a/src/views/MainPage/lib/useTabs.ts
+++ b/src/views/MainPage/lib/useTabs.ts
@@ -1,10 +1,10 @@
 import { useState } from 'react';
 
-interface TabType {
+interface ExtraTabType {
   type: string;
 }
 
-export function useTabs<T extends TabType>(initialTab: T, allTabs: T[]) {
+export function useTabs<T extends ExtraTabType>(initialTab: T, allTabs: T[]) {
   const [currentTab, setCurrentTab] = useState(initialTab);
   const changeTab = (tabType: string) => {
     const shouldChangeTab = allTabs.find(({ type }) => type === tabType);

--- a/src/views/ReviewPage/ReviewPage.tsx
+++ b/src/views/ReviewPage/ReviewPage.tsx
@@ -1,13 +1,13 @@
 import styled from '@emotion/styled';
 import { useState } from 'react';
 import { Footer, Header, Layout, ScrollToTopButton } from '@src/components';
-import { ReviewTabExtraType, ReviewTabType } from '@src/lib/types/review';
+import { ExtraPart, PartExtraType } from '@src/lib/types/universal';
 import Description from './components/Description';
 import Reviews from './components/Reviews';
 import TabBar from './components/TabBar';
 
 function ReviewPage() {
-  const [selectedTab, setSelectedTab] = useState<ReviewTabType>(ReviewTabExtraType.ALL);
+  const [selectedTab, setSelectedTab] = useState<ExtraPart>(PartExtraType.ALL);
 
   return (
     <Layout>

--- a/src/views/ReviewPage/components/Reviews/index.tsx
+++ b/src/views/ReviewPage/components/Reviews/index.tsx
@@ -1,13 +1,13 @@
 import { useMemo } from 'react';
 import { useIsMobile } from '@src/hooks/useDevice';
-import { ReviewTabType } from '@src/lib/types/review';
+import { ExtraPart } from '@src/lib/types/universal';
 import { OvalSpinner } from '@src/views/ProjectPage/components';
 import useFetch from '../../hooks/useFetch';
 import { logoPath } from '../../libs/constants';
 import * as S from './style';
 
 type ReviewsProps = {
-  selectedTab: ReviewTabType;
+  selectedTab: ExtraPart;
 };
 
 const Reviews = ({ selectedTab }: ReviewsProps) => {

--- a/src/views/ReviewPage/components/TabBar/index.tsx
+++ b/src/views/ReviewPage/components/TabBar/index.tsx
@@ -1,10 +1,10 @@
-import { ReviewTabType, TabType } from '@src/lib/types/review';
+import { ExtraPart, ExtraTabType } from '@src/lib/types/universal';
 import { tabs } from '../../libs/constants';
 import * as S from './style';
 
 type TabBarProps = {
-  selectedTab: ReviewTabType;
-  onTabClick(targetTab: ReviewTabType): void;
+  selectedTab: ExtraPart;
+  onTabClick(targetTab: ExtraPart): void;
 };
 
 const TabBar = ({ onTabClick, selectedTab }: TabBarProps) => {
@@ -24,7 +24,7 @@ const TabBar = ({ onTabClick, selectedTab }: TabBarProps) => {
 
 type TabProps = {
   onClick(): void;
-  tab: TabType;
+  tab: ExtraTabType;
   selected: boolean;
 };
 

--- a/src/views/ReviewPage/hooks/useFetch.ts
+++ b/src/views/ReviewPage/hooks/useFetch.ts
@@ -2,10 +2,10 @@ import { useCallback, useEffect } from 'react';
 import useBooleanState from '@src/hooks/useBooleanState';
 import useStackedFetchBase from '@src/hooks/useStackedFetchBase';
 import { api } from '@src/lib/api';
-import { ReviewTabType } from '@src/lib/types/review';
+import { ExtraPart } from '@src/lib/types/universal';
 import useInfiniteScroll from './useInfiniteScroll';
 
-const useFetch = (selected: ReviewTabType) => {
+const useFetch = (selected: ExtraPart) => {
   const { ref, count, setCount } = useInfiniteScroll();
   const [canGetMoreReviews, setCanGetMoreReviews, setCanNotGetMoreReviews] = useBooleanState(true);
 

--- a/src/views/ReviewPage/libs/constants.ts
+++ b/src/views/ReviewPage/libs/constants.ts
@@ -1,10 +1,9 @@
 import * as L from '@src/assets/mainLogo';
-import { ReviewTabExtraType, TabType } from '@src/lib/types/review';
-import { Part } from '@src/lib/types/universal';
+import { ExtraTabType, Part, PartExtraType } from '@src/lib/types/universal';
 
-export const tabs: TabType[] = [
+export const tabs: ExtraTabType[] = [
   {
-    value: ReviewTabExtraType.ALL,
+    value: PartExtraType.ALL,
     label: '전체',
   },
   {


### PR DESCRIPTION
## Summary
- 커리큘럼 섹션을 구현합니다
- 릴레이를 위하여 https://github.com/sopt-makers/sopt.org-frontend/pull/113 에서 브랜치를 파 진행하였습니다 (이후 머지 시에 develop으로 순차적으로 머지하면 될 듯 합니다!)
- Flex 컴포넌트 정말 잘 썼습니다🙏🏼🙏🏼

## Screenshot

https://user-images.githubusercontent.com/47105088/235663147-d685d0ca-be5d-4ccb-8059-76eddeabfb44.mp4

## Comment
- 특이사항 하나는, 리뷰 페이지에서 서진이가 제작해둔 `TapType` 의 재활용을 위해 `types/universal` 로 옮기고, "전체가 없는 탭 타입"과 "전체가 있는 탭 타입"을 나누었습니다. 이를 위해 타입명도 바꾸게 되었는데, 피드백 마음껏 주셔도 좋습니다! 5b3e05f366a5676d45eb119563f1d75ef50139f0 해당 커밋에 작업이 담겨져 있습니다