### PR TITLE
#111 about 탭 멤버 섹션 구현

### DIFF
--- a/src/views/AboutPage/AboutPage.tsx
+++ b/src/views/AboutPage/AboutPage.tsx
@@ -3,6 +3,7 @@ import { Footer, Header, Layout } from '@src/components';
 import Banner from './components/Banner';
 import CirriculumSection from './components/Cirriculum/Section';
 import CoreValueSection from './components/CoreValue/Section';
+import MemberSection from './components/Member/Section';
 import useFetch from './hooks/useFetch';
 
 const AboutPage = () => {
@@ -23,6 +24,7 @@ const AboutPage = () => {
             coreValues={state.data.aboutInfo.coreValue.eachValues}
           />
           <CirriculumSection cirriculums={state.data.aboutInfo.curriculums} />
+          <MemberSection generation={state.data.aboutInfo.generation} />
         </Root>
       )}
       <Footer />

--- a/src/views/AboutPage/components/Member/Card/index.tsx
+++ b/src/views/AboutPage/components/Member/Card/index.tsx
@@ -1,0 +1,24 @@
+import Image from 'next/image';
+import * as St from './style';
+
+type MeberCardProps = {
+  imgSrc: string;
+  name: string;
+  description: string;
+  part: string;
+};
+
+const MemberCard = ({ imgSrc, name, description, part }: MeberCardProps) => {
+  return (
+    <St.Card>
+      <St.ImageWrapper>
+        <Image src={imgSrc} alt={name} fill />
+      </St.ImageWrapper>
+      <St.Name>{name}</St.Name>
+      <St.Desc>{description}</St.Desc>
+      <St.Part>{part}</St.Part>
+    </St.Card>
+  );
+};
+
+export default MemberCard;

--- a/src/views/AboutPage/components/Member/Card/style.ts
+++ b/src/views/AboutPage/components/Member/Card/style.ts
@@ -1,0 +1,125 @@
+import styled from '@emotion/styled';
+import { textSingularLineEllipsis } from '@src/styles/textEllipsis';
+
+export const Card = styled.article`
+  ${textSingularLineEllipsis}
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  width: 270px;
+  height: 400px;
+
+  margin-bottom: 60px;
+  padding: 38px 49px;
+
+  background: #000000;
+  border-radius: 10px;
+
+  /* 태블릿 뷰 */
+  @media (max-width: 1199px) and (min-width: 766px) {
+    width: 209px;
+    height: 300px;
+
+    margin-bottom: 40px;
+    padding: 26px 40px;
+  }
+  /* 모바일 뷰 */
+  @media (max-width: 765.9px) {
+    width: 160px;
+    height: 265px;
+
+    margin-bottom: 32px;
+    padding: 18px 17px;
+  }
+`;
+
+export const ImageWrapper = styled.div`
+  position: relative;
+
+  width: 180px;
+  height: 180px;
+
+  border-radius: 50%;
+  overflow: hidden;
+
+  /* 태블릿, 모바일 뷰 */
+  @media (max-width: 1199px) {
+    width: 126px;
+    height: 126px;
+  }
+`;
+
+export const Name = styled.strong`
+  margin-top: 24px;
+
+  font-weight: 700;
+  font-size: 28px;
+  letter-spacing: -0.01em;
+
+  color: #ffffff;
+
+  /* 태블릿 뷰 */
+  @media (max-width: 1199px) and (min-width: 766px) {
+    margin-top: 16px;
+
+    font-size: 18px;
+  }
+  /* 모바일 뷰 */
+  @media (max-width: 765.9px) {
+    margin-top: 16px;
+
+    font-size: 16px;
+  }
+`;
+
+export const Desc = styled.p`
+  margin-top: 8px;
+  font-size: 18px;
+  line-height: 26px;
+  letter-spacing: -0.01em;
+  color: rgba(255, 255, 255, 0.5);
+  /* 모바일 뷰 */
+  @media (max-width: 765.9px) {
+    margin-top: 4px;
+    font-size: 16px;
+  }
+`;
+
+export const Part = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  margin-top: 12px;
+  padding: 10px 16px;
+
+  background: #333333;
+  border-radius: 30px;
+
+  font-size: 18px;
+  line-height: 26px;
+  letter-spacing: -0.01em;
+
+  color: #ffffff;
+
+  /* 태블릿 뷰 */
+  @media (max-width: 1199px) and (min-width: 766px) {
+    margin-top: 8px;
+    padding: 10px 16px;
+
+    background: #333333;
+    border-radius: 30px;
+
+    font-size: 18px;
+    line-height: 26px;
+  }
+  /* 모바일 뷰 */
+  @media (max-width: 765.9px) {
+    margin-top: 6px;
+
+    font-size: 12px;
+    line-height: 15px;
+  }
+`;

--- a/src/views/AboutPage/components/Member/Content/index.tsx
+++ b/src/views/AboutPage/components/Member/Content/index.tsx
@@ -2,24 +2,28 @@ import { useState } from 'react';
 import Flex from '@src/components/common/Flex';
 import { ExtraPart } from '@src/lib/types/universal';
 import { PartExtraType } from '@src/lib/types/universal';
+import useFetchMember from '@src/views/AboutPage/hooks/useFetchMemeber';
 import TabBar from '../../common/TabBar';
 import MemberCard from '../Card';
 import * as St from './style';
 
 const MemberContent = () => {
   const [currentPart, setCurrentPart] = useState<ExtraPart>(PartExtraType.ALL);
+  const state = useFetchMember(currentPart);
+
+  if (state._TAG !== 'OK') return null;
 
   return (
     <Flex dir="column" gap={{ mobile: 18, tablet: 24, desktop: 48 }}>
       <TabBar onTabClick={setCurrentPart} selectedTab={currentPart} includesExtra={true} />
       <St.CardContainer>
-        {Array.from({ length: 9 }).map((member, i) => (
+        {state.data.members.map((member, idx) => (
           <MemberCard
-            key={i}
-            imgSrc="https://avatars.githubusercontent.com/u/47105088?v=4"
-            name="박이정"
-            description="안채량박서원최영훈"
-            part="Android 파트장"
+            key={`${member.name}-${idx}`}
+            imgSrc={member.src}
+            name={member.name}
+            description={member.description}
+            part={member.part}
           />
         ))}
       </St.CardContainer>

--- a/src/views/AboutPage/components/Member/Content/index.tsx
+++ b/src/views/AboutPage/components/Member/Content/index.tsx
@@ -1,0 +1,30 @@
+import { useState } from 'react';
+import Flex from '@src/components/common/Flex';
+import { ExtraPart } from '@src/lib/types/universal';
+import { PartExtraType } from '@src/lib/types/universal';
+import TabBar from '../../common/TabBar';
+import MemberCard from '../Card';
+import * as St from './style';
+
+const MemberContent = () => {
+  const [currentPart, setCurrentPart] = useState<ExtraPart>(PartExtraType.ALL);
+
+  return (
+    <Flex dir="column" gap={{ mobile: 18, tablet: 24, desktop: 48 }}>
+      <TabBar onTabClick={setCurrentPart} selectedTab={currentPart} includesExtra={true} />
+      <St.CardContainer>
+        {Array.from({ length: 9 }).map((member, i) => (
+          <MemberCard
+            key={i}
+            imgSrc="https://avatars.githubusercontent.com/u/47105088?v=4"
+            name="박이정"
+            description="안채량박서원최영훈"
+            part="Android 파트장"
+          />
+        ))}
+      </St.CardContainer>
+    </Flex>
+  );
+};
+
+export default MemberContent;

--- a/src/views/AboutPage/components/Member/Content/style.ts
+++ b/src/views/AboutPage/components/Member/Content/style.ts
@@ -1,0 +1,15 @@
+import styled from '@emotion/styled';
+
+export const CardContainer = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 30px;
+  /* 태블릿 뷰 */
+  @media (max-width: 1199px) and (min-width: 766px) {
+    gap: 20px;
+  }
+  /* 모바일 뷰 */
+  @media (max-width: 765.9px) {
+    gap: 10px;
+  }
+`;

--- a/src/views/AboutPage/components/Member/Section/index.tsx
+++ b/src/views/AboutPage/components/Member/Section/index.tsx
@@ -1,0 +1,18 @@
+import Flex from '@src/components/common/Flex';
+import SectionTitle from '../../common/SectionTitle';
+import MemberContent from '../Content';
+
+type MemberSectionProps = {
+  generation: number;
+};
+
+const MemberSection = ({ generation }: MemberSectionProps) => {
+  return (
+    <Flex dir="column" gap={{ mobile: 24, tablet: 48, desktop: 60 }}>
+      <SectionTitle>{generation}기 활동 멤버들</SectionTitle>
+      <MemberContent />
+    </Flex>
+  );
+};
+
+export default MemberSection;

--- a/src/views/AboutPage/hooks/useFetchMemeber.ts
+++ b/src/views/AboutPage/hooks/useFetchMemeber.ts
@@ -1,0 +1,17 @@
+import { useCallback } from 'react';
+import useFetchBase from '@src/hooks/useFetchBase';
+import { api } from '@src/lib/api';
+import { ExtraPart, PartExtraType } from '@src/lib/types/universal';
+
+const useFetchMember = (part: ExtraPart) => {
+  const willFetch = useCallback(async () => {
+    const response = await api.aboutAPI.getMemberInfo(
+      part === PartExtraType.ALL ? undefined : part,
+    );
+    return response;
+  }, [part]);
+  const state = useFetchBase(willFetch);
+  return state;
+};
+
+export default useFetchMember;

--- a/src/views/ProjectPage/components/filter/DesktopFilter.tsx
+++ b/src/views/ProjectPage/components/filter/DesktopFilter.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react';
 import { ReactComponent as ToggleArrowBtn } from '@src/assets/icons/ToggleArrow.svg';
 import { Condition } from '@src/lib';
+import { ProjectCategoryType } from '@src/lib/types/project';
 import cc from 'classcat';
-import { ProjectCategoryType, projectCategoryList } from '../../lib/constants';
+import { projectCategoryList } from '../../lib/constants';
 import styles from './project-filter-desktop.module.scss';
 
 type ModalProps = {

--- a/src/views/ProjectPage/components/filter/MobileFilter.tsx
+++ b/src/views/ProjectPage/components/filter/MobileFilter.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Condition } from '@src/lib';
-import { ProjectCategoryType } from '../../lib/constants';
+import { ProjectCategoryType } from '@src/lib/types/project';
 import { MobileFilterModal } from './MobileFilterModal';
 import { MobileUtilityButton } from './MobileUtilityButton';
 

--- a/src/views/ProjectPage/components/filter/MobileFilterModal.tsx
+++ b/src/views/ProjectPage/components/filter/MobileFilterModal.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react';
 import { ReactComponent as ToggleArrowBtn } from '@src/assets/icons/ToggleArrow.svg';
 import { Condition } from '@src/lib';
+import { ProjectCategoryType } from '@src/lib/types/project';
 import cc from 'classcat';
-import { ProjectCategoryType, projectCategoryList } from '../../lib/constants';
+import { projectCategoryList } from '../../lib/constants';
 import styles from './project-filter-mobile.module.scss';
 
 type ModalProps = {

--- a/src/views/ProjectPage/components/filter/ProjectFilter.tsx
+++ b/src/views/ProjectPage/components/filter/ProjectFilter.tsx
@@ -1,6 +1,6 @@
 import { Dispatch, SetStateAction } from 'react';
 import { useIsDesktop, useIsMobile, useIsTablet } from '@src/hooks/useDevice';
-import { ProjectCategoryType } from '../../lib/constants';
+import { ProjectCategoryType } from '@src/lib/types/project';
 import { DesktopFilter } from './DesktopFilter';
 import { MobileFilter } from './MobileFilter';
 


### PR DESCRIPTION
## Summary
- 멤버 패칭 부분, 구현하였습니다
  - [ ] 컨텐츠가 카드 범위를 넘어가는 현상이 우려되는데, QA 기간 전후로 디자이너와 상의하고자 합니다
  - [ ] 서버 API를 붙이며, 로딩 스피너를 부착할까 고민해보겠습니다!

## Screenshot


https://user-images.githubusercontent.com/47105088/236119405-596ef92c-099c-474d-a5e9-89088d02c84b.mp4



## Comment

해당 섹션이 맨 아래에 위치한 섹션이기 때문에, About 탭에서 lazy loading 을 하여 최후순위로 렌더링 하고자 하는데, 어떻게 생각하실니다까요!?