### PR TITLE
feat: implement about pages' study api

### DIFF
--- a/src/lib/api/mock/about.ts
+++ b/src/lib/api/mock/about.ts
@@ -1,4 +1,8 @@
-import { GetAboutInfoResponse, GetMembersInfoResponse } from '@src/lib/types/about';
+import {
+  GetAboutInfoResponse,
+  GetMembersInfoResponse,
+  GetStudyInfoResponse,
+} from '@src/lib/types/about';
 import { Part } from '@src/lib/types/universal';
 
 const BANNER_SRC = 'https://i.ibb.co/84ybMKQ/image-76.png';
@@ -60,7 +64,22 @@ const getMemberInfo = async (part?: Part): Promise<GetMembersInfoResponse> => ({
   ).flat(),
 });
 
+const getStudyInfo = async (): Promise<GetStudyInfoResponse> => ({
+  studies: Array.from({ length: 23 }, (idx: number) => ({
+    id: idx,
+    generation: 30,
+    joinableParts: [Part.ANDROID, Part.PLAN],
+    title: '안드러와',
+    src: SRC,
+    startDate: new Date('2022-01-01'),
+    endDate: new Date('2022-08-01'),
+    membersCount: 40,
+  })),
+  hasNextPage: true,
+});
+
 export const mockAboutAPI = {
   getAboutInfo,
   getMemberInfo,
+  getStudyInfo,
 };

--- a/src/lib/types/about.ts
+++ b/src/lib/types/about.ts
@@ -29,6 +29,17 @@ export interface AboutInfoType {
   };
 }
 
+export interface StudyInfoType {
+  id: number;
+  generation: number;
+  joinableParts: Part[];
+  title: string;
+  src: string;
+  startDate: Date;
+  endDate: Date;
+  membersCount: number;
+}
+
 export interface GetMembersInfoResponse {
   members: MemberType[];
 }
@@ -37,7 +48,13 @@ export interface GetAboutInfoResponse {
   aboutInfo: AboutInfoType;
 }
 
+export interface GetStudyInfoResponse {
+  studies: StudyInfoType[];
+  hasNextPage: boolean;
+}
+
 export interface AboutAPI {
   getAboutInfo(): Promise<GetAboutInfoResponse>;
   getMemberInfo(part?: Part): Promise<GetMembersInfoResponse>;
+  getStudyInfo(generation?: number): Promise<GetStudyInfoResponse>;
 }

--- a/src/pages/study.tsx
+++ b/src/pages/study.tsx
@@ -1,0 +1,1 @@
+export { default } from '@src/views/StudyPage';

--- a/src/utils/dateFormat.ts
+++ b/src/utils/dateFormat.ts
@@ -4,3 +4,18 @@ export const dateFormat = (date: string) => {
 
   return splitedDate[0] + '.' + splitedDate[1];
 };
+
+export const formatDate = (date: Date, format: 'yyyymmdd' | 'mmdd'): string => {
+  switch (format) {
+    case 'yyyymmdd':
+      return date.toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+      });
+    case 'mmdd':
+      return date.toLocaleDateString('en-US', { month: '2-digit', day: '2-digit' });
+    default:
+      return date.toLocaleDateString();
+  }
+};

--- a/src/views/AboutPage/AboutPage.tsx
+++ b/src/views/AboutPage/AboutPage.tsx
@@ -3,6 +3,7 @@ import { Footer, Header, Layout } from '@src/components';
 import Banner from './components/Banner';
 import CirriculumSection from './components/Cirriculum/Section';
 import CoreValueSection from './components/CoreValue/Section';
+import RecordSection from './components/Record/Section';
 import useFetch from './hooks/useFetch';
 
 const AboutPage = () => {
@@ -23,6 +24,10 @@ const AboutPage = () => {
             coreValues={state.data.aboutInfo.coreValue.eachValues}
           />
           <CirriculumSection cirriculums={state.data.aboutInfo.curriculums} />
+          <RecordSection
+            generation={state.data.aboutInfo.generation}
+            records={state.data.aboutInfo.records}
+          />
         </Root>
       )}
       <Footer />

--- a/src/views/AboutPage/components/Record/Item/index.tsx
+++ b/src/views/AboutPage/components/Record/Item/index.tsx
@@ -1,0 +1,25 @@
+import Flex from '@src/components/common/Flex';
+import * as St from './style';
+
+type RecordItemProps = {
+  href: string;
+  title: string;
+  count: string;
+};
+
+const RecordItem = (props: RecordItemProps) => {
+  return (
+    <St.LinkWrapper href={props.href}>
+      <Flex
+        dir="column"
+        gap={{ mobile: 4, tablet: 8, desktop: 8 }}
+        style={{ alignItems: 'center', justifyContent: 'center', height: '100%' }}
+      >
+        <St.Title>{props.title}</St.Title>
+        <St.Count>{props.count}</St.Count>
+      </Flex>
+    </St.LinkWrapper>
+  );
+};
+
+export default RecordItem;

--- a/src/views/AboutPage/components/Record/Item/style.ts
+++ b/src/views/AboutPage/components/Record/Item/style.ts
@@ -1,0 +1,73 @@
+import styled from '@emotion/styled';
+import Link from 'next/link';
+import arrowRight from '@src/assets/icons/arrow-right-16x16.svg';
+
+export const LinkWrapper = styled(Link)`
+  width: 100%;
+  background-color: #000000;
+  border-radius: 10px;
+  height: 280px;
+  /* 태블릿 뷰 */
+  @media (max-width: 1199px) and (min-width: 766px) {
+    height: 180px;
+  }
+  /* 모바일 뷰 */
+  @media (max-width: 765.9px) {
+    height: 120px;
+  }
+`;
+
+export const Title = styled.div`
+  font-size: 20px;
+  letter-spacing: -1%;
+  color: white;
+
+  /* 태블릿 뷰 */
+  @media (max-width: 1199px) and (min-width: 766px) {
+    font-size: 18px;
+  }
+  /* 모바일 뷰 */
+  @media (max-width: 765.9px) {
+    font-size: 12px;
+  }
+`;
+
+export const Count = styled.div`
+  position: relative;
+  font-weight: 600;
+  font-size: 45px;
+  color: white;
+  /* 태블릿 뷰 */
+  @media (max-width: 1199px) and (min-width: 766px) {
+    font-size: 28px;
+  }
+  /* 모바일 뷰 */
+  @media (max-width: 765.9px) {
+    font-size: 18px;
+  }
+
+  &::after {
+    position: absolute;
+    content: '';
+    mask-image: url(${arrowRight});
+    mask-repeat: no-repeat;
+    mask-size: cover;
+    background-color: #787878;
+    width: 32px;
+    height: 40px;
+    margin-top: 2px;
+
+    /* 태블릿 뷰 */
+    @media (max-width: 1199px) and (min-width: 766px) {
+      width: 16px;
+      height: 20px;
+      margin-top: 4px;
+    }
+    /* 모바일 뷰 */
+    @media (max-width: 765.9px) {
+      width: 12px;
+      height: 15px;
+      margin-top: 0;
+    }
+  }
+`;

--- a/src/views/AboutPage/components/Record/List/index.tsx
+++ b/src/views/AboutPage/components/Record/List/index.tsx
@@ -1,0 +1,17 @@
+import Flex from '@src/components/common/Flex';
+import { AboutInfoType } from '@src/lib/types/about';
+import RecordItem from '../Item';
+
+type RecordListProps = Pick<AboutInfoType, 'records'>;
+
+const RecordList = (props: RecordListProps) => {
+  return (
+    <Flex dir="row" gap={{ mobile: 8, tablet: 20, desktop: 30 }}>
+      <RecordItem title="활동 멤버" count={`${props.records.memberCount}명`} href="/" />
+      <RecordItem title="프로젝트" count={`${props.records.projectCount}개`} href="/project" />
+      <RecordItem title="스터디" count={`${props.records.studyCount}개`} href="/study" />
+    </Flex>
+  );
+};
+
+export default RecordList;

--- a/src/views/AboutPage/components/Record/Section/index.tsx
+++ b/src/views/AboutPage/components/Record/Section/index.tsx
@@ -1,0 +1,17 @@
+import Flex from '@src/components/common/Flex';
+import { AboutInfoType } from '@src/lib/types/about';
+import SectionTitle from '../../common/SectionTitle';
+import RecordList from '../List';
+
+type RecordSectionProps = Pick<AboutInfoType, 'generation' | 'records'>;
+
+const RecordSection = (props: RecordSectionProps) => {
+  return (
+    <Flex dir="column" gap={{ mobile: 24, tablet: 48, desktop: 64 }}>
+      <SectionTitle>{props.generation}기 활동 레코드</SectionTitle>
+      <RecordList records={props.records} />
+    </Flex>
+  );
+};
+
+export default RecordSection;

--- a/src/views/StudyPage/StudyPage.tsx
+++ b/src/views/StudyPage/StudyPage.tsx
@@ -1,0 +1,63 @@
+import styled from '@emotion/styled';
+import { Footer, Header, Layout } from '@src/components';
+import StudySection from './components/Section';
+import useFetch from './hooks/useFetch';
+
+const StudyPage = () => {
+  const state = useFetch();
+
+  return (
+    <Layout>
+      <Header />
+      {state._TAG === 'OK' && (
+        <Root>
+          <Title>스터디</Title>
+          <StudySection studies={state.data.studies} />
+        </Root>
+      )}
+      <Footer />
+    </Layout>
+  );
+};
+
+export default StudyPage;
+
+const Root = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 1200px;
+  min-height: 100vh;
+  margin: 0 auto;
+
+  /* 태블릿 뷰 */
+  @media (max-width: 1199px) and (min-width: 766px) {
+    width: 700px;
+    margin-top: 90px;
+  }
+  /* 모바일 뷰 */
+  @media (max-width: 765.9px) {
+    width: 360px;
+    margin-top: 90px;
+  }
+`;
+
+const Title = styled.h1`
+  text-align: center;
+  font-size: 45px;
+  line-height: 60px;
+  letter-spacing: -1%;
+  margin-top: 120px;
+
+  /* 태블릿 뷰 */
+  @media (max-width: 1199px) and (min-width: 766px) {
+    font-size: 36px;
+    line-height: 56px;
+    margin-top: 70px;
+  }
+  /* 모바일 뷰 */
+  @media (max-width: 765.9px) {
+    font-size: 24px;
+    line-height: 28px;
+    margin-top: 30px;
+  }
+`;

--- a/src/views/StudyPage/components/Item/index.tsx
+++ b/src/views/StudyPage/components/Item/index.tsx
@@ -1,0 +1,62 @@
+import Image from 'next/image';
+import { useMemo } from 'react';
+import Flex from '@src/components/common/Flex';
+import { StudyInfoType } from '@src/lib/types/about';
+import { formatDate } from '@src/utils/dateFormat';
+import { parsePartToKorean } from '@src/views/MainPage/components/ActivityReview/utils/parsePartToKorean';
+import * as St from './style';
+
+type StudyItemProps = {
+  study: StudyInfoType;
+};
+
+const StudyItem = (props: StudyItemProps) => {
+  return (
+    <Flex dir="column" gap={{ desktop: 24, tablet: 24, mobile: 15 }}>
+      <St.CardWrapper>
+        <Image src={props.study.src} alt={props.study.title} fill />
+        <Flex dir="row" gap={6} style={{ position: 'relative' }}>
+          <St.ChipHighlighted>{props.study.generation}기</St.ChipHighlighted>
+          {props.study.joinableParts.map((part) => (
+            <St.ChipNormal key={part}>{parsePartToKorean(part)}</St.ChipNormal>
+          ))}
+        </Flex>
+      </St.CardWrapper>
+      <St.DescriptionWrapper>
+        <St.Title>{props.study.title}</St.Title>
+        <div>
+          <StudyDateSection startDate={props.study.startDate} endDate={props.study.endDate} />
+          <St.SpanWrapper>
+            <St.SpanHighlighted>{props.study.membersCount}명</St.SpanHighlighted>
+            <St.SpanNormal>과 함께했어요</St.SpanNormal>
+          </St.SpanWrapper>
+        </div>
+      </St.DescriptionWrapper>
+    </Flex>
+  );
+};
+
+type StudyDateSectionProps = {
+  startDate: Date;
+  endDate: Date;
+};
+const StudyDateSection = (props: StudyDateSectionProps) => {
+  const isSameYear = useMemo(
+    () => props.startDate.getFullYear() === props.endDate.getFullYear(),
+    [props.startDate, props.endDate],
+  );
+  const startDateString = useMemo(() => formatDate(props.startDate, 'yyyymmdd'), [props.startDate]);
+
+  const endDateString = useMemo(
+    () => formatDate(props.endDate, isSameYear ? 'mmdd' : 'yyyymmdd'),
+    [props.endDate, isSameYear],
+  );
+
+  return (
+    <St.SpanNormal>
+      {startDateString} ~ {endDateString}
+    </St.SpanNormal>
+  );
+};
+
+export default StudyItem;

--- a/src/views/StudyPage/components/Item/style.ts
+++ b/src/views/StudyPage/components/Item/style.ts
@@ -1,0 +1,86 @@
+import styled from '@emotion/styled';
+
+export const CardWrapper = styled.div`
+  width: 100%;
+  position: relative;
+  border-radius: 10px;
+  overflow: hidden;
+  height: 240px;
+  padding: 18px;
+
+  /* 태블릿, 모바일 뷰 */
+  @media (max-width: 1199px) {
+    height: 202px;
+    padding: 16px;
+  }
+`;
+
+export const DescriptionWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  /* 모바일 뷰 */
+  @media (max-width: 765.9px) {
+    padding: 0 10px;
+  }
+`;
+
+export const SpanWrapper = styled.div``;
+
+const Span = styled.span`
+  font-size: 18px;
+  line-height: 26px;
+  letter-spacing: -1%;
+
+  /* 태블릿 뷰 */
+  @media (max-width: 1199px) and (min-width: 766px) {
+  }
+  /* 모바일 뷰 */
+  @media (max-width: 765.9px) {
+    font-size: 16px;
+    line-height: 25px;
+  }
+`;
+
+export const SpanHighlighted = styled(Span)`
+  color: white;
+  font-weight: 600;
+`;
+
+export const SpanNormal = styled(Span)`
+  color: #787878;
+`;
+
+const Chip = styled.div`
+  background-color: #313131;
+  padding: 9px 12px;
+  border-radius: 10px;
+  font-size: 18px;
+  letter-spacing: -1%;
+
+  /* 모바일 뷰 */
+  @media (max-width: 765.9px) {
+    padding: 6px 12px;
+    font-size: 14px;
+    line-height: 120%;
+  }
+`;
+
+export const ChipHighlighted = styled(Chip)`
+  color: white;
+`;
+
+export const ChipNormal = styled(Chip)`
+  color: rgba(255, 255, 255, 60%);
+`;
+
+export const Title = styled.div`
+  color: white;
+  font-size: 26px;
+  letter-spacing: -1%;
+
+  /* 모바일 뷰 */
+  @media (max-width: 765.9px) {
+    font-size: 20px;
+  }
+`;

--- a/src/views/StudyPage/components/List/index.tsx
+++ b/src/views/StudyPage/components/List/index.tsx
@@ -1,0 +1,19 @@
+import { StudyInfoType } from '@src/lib/types/about';
+import StudyItem from '../Item';
+import { GridWrapper } from './style';
+
+type StudyListProps = {
+  studies: StudyInfoType[];
+};
+
+const StudyList = (props: StudyListProps) => {
+  return (
+    <GridWrapper>
+      {props.studies.map((study) => (
+        <StudyItem key={study.id} study={study} />
+      ))}
+    </GridWrapper>
+  );
+};
+
+export default StudyList;

--- a/src/views/StudyPage/components/List/style.ts
+++ b/src/views/StudyPage/components/List/style.ts
@@ -1,0 +1,21 @@
+import styled from '@emotion/styled';
+
+export const GridWrapper = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  max-width: 1194px;
+  row-gap: 45px;
+  column-gap: 60px;
+
+  /* 태블릿 뷰 */
+  @media (max-width: 1199px) and (min-width: 766px) {
+    grid-template-columns: 1fr 1fr;
+    row-gap: 30px;
+    column-gap: 70px;
+  }
+  /* 모바일 뷰 */
+  @media (max-width: 765.9px) {
+    grid-template-columns: 1fr;
+    column-gap: 30px;
+  }
+`;

--- a/src/views/StudyPage/components/Section/index.tsx
+++ b/src/views/StudyPage/components/Section/index.tsx
@@ -1,0 +1,24 @@
+import Flex from '@src/components/common/Flex';
+import { StudyInfoType } from '@src/lib/types/about';
+import StudyList from '../List';
+import * as St from './style';
+
+type StudySectionProps = {
+  studies: StudyInfoType[];
+};
+
+const StudySection = (props: StudySectionProps) => {
+  return (
+    <St.Wrapper>
+      <Flex dir="column" gap={{ desktop: 60, tablet: 54, mobile: 36 }}>
+        <St.SpanWrapper>
+          <St.SpanHighlighted>{props.studies.length}개</St.SpanHighlighted>
+          <St.SpanNormal>의 스터디가 주도적으로 진행되었어요</St.SpanNormal>
+        </St.SpanWrapper>
+        <StudyList studies={props.studies} />
+      </Flex>
+    </St.Wrapper>
+  );
+};
+
+export default StudySection;

--- a/src/views/StudyPage/components/Section/style.ts
+++ b/src/views/StudyPage/components/Section/style.ts
@@ -1,0 +1,46 @@
+import styled from '@emotion/styled';
+
+export const Wrapper = styled.div`
+  padding-top: 80px;
+  padding-bottom: 240px;
+
+  /* 태블릿 뷰 */
+  @media (max-width: 1199px) and (min-width: 766px) {
+    padding-top: 36px;
+  }
+  /* 모바일 뷰 */
+  @media (max-width: 765.9px) {
+    padding-top: 28px;
+  }
+`;
+
+export const SpanWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+`;
+
+const Span = styled.span`
+  font-size: 30px;
+  line-height: 30px;
+  letter-spacing: -1%;
+
+  /* 태블릿 뷰 */
+  @media (max-width: 1199px) and (min-width: 766px) {
+    font-size: 26px;
+    line-height: 26px;
+  }
+  /* 모바일 뷰 */
+  @media (max-width: 765.9px) {
+    font-size: 15px;
+    line-height: 25px;
+  }
+`;
+
+export const SpanHighlighted = styled(Span)`
+  color: white;
+  font-weight: 600;
+`;
+
+export const SpanNormal = styled(Span)`
+  color: #787878;
+`;

--- a/src/views/StudyPage/hooks/useFetch.ts
+++ b/src/views/StudyPage/hooks/useFetch.ts
@@ -1,0 +1,14 @@
+import { useCallback } from 'react';
+import useFetchBase from '@src/hooks/useFetchBase';
+import { api } from '@src/lib/api';
+
+const useFetch = () => {
+  const willFetch = useCallback(async () => {
+    const response = await api.aboutAPI.getStudyInfo();
+    return response;
+  }, []);
+  const state = useFetchBase(willFetch);
+  return state;
+};
+
+export default useFetch;

--- a/src/views/StudyPage/index.tsx
+++ b/src/views/StudyPage/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './StudyPage';


### PR DESCRIPTION
## Summary
어바웃 페이지의 record 섹션과 스터디 페이지를 추가합니다.

스터디 관련 API도 추가했습니다.

## Screenshot

D | T | M
--|--|--
<img height="120" alt="image" src="https://user-images.githubusercontent.com/48249505/236363784-baa4a499-0279-4ca1-b95c-efb7628082f6.png">|<img height="120" alt="image" src="https://user-images.githubusercontent.com/48249505/236363814-94da4261-7e5a-410c-9088-0c64ae8cef46.png">|<img height="120" alt="image" src="https://user-images.githubusercontent.com/48249505/236363836-5ce39304-a7a5-4701-9c9c-5211f10e69e1.png">
<img height="120" alt="image" src="https://user-images.githubusercontent.com/48249505/236364004-0e677b31-f7ac-4947-a6fa-9be090ce14cc.png">|<img height="120" alt="image" src="https://user-images.githubusercontent.com/48249505/236363965-96265667-f04a-4e12-9a3f-ce5866a4eceb.png">|<img height="120" alt="image" src="https://user-images.githubusercontent.com/48249505/236363913-ac720584-4820-47af-a02a-31a0c91cef0c.png">


## Comment
