### PR TITLE
SPR2 QA : hover 상태 추가

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["next/babel"],
+  "plugins": ["@emotion"]
+}

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@babel/plugin-transform-runtime": "^7.18.10",
     "@babel/preset-env": "^7.18.2",
     "@babel/runtime": "^7.18.9",
-    "@emotion/babel-plugin": "^11.9.2",
+    "@emotion/babel-plugin": "^11.10.0",
     "@svgr/webpack": "^6.5.0",
     "@testing-library/dom": "^8.13.0",
     "@testing-library/jest-dom": "^5.16.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ specifiers:
   '@babel/plugin-transform-runtime': ^7.18.10
   '@babel/preset-env': ^7.18.2
   '@babel/runtime': ^7.18.9
-  '@emotion/babel-plugin': ^11.9.2
+  '@emotion/babel-plugin': ^11.10.0
   '@emotion/react': ^11.9.0
   '@emotion/styled': ^11.8.1
   '@svgr/webpack': ^6.5.0

--- a/src/components/Header/Desktop/DesktopHeader.tsx
+++ b/src/components/Header/Desktop/DesktopHeader.tsx
@@ -229,6 +229,9 @@ export const MenuTitleAnchor = styled(Link)`
   background-color: #504ebf;
   padding: 6px 32px;
   border-radius: 30px;
+  &:hover {
+    background-color: #413fac;
+  }
 `;
 
 const menuTitleUnderline = css`

--- a/src/components/corporate/JobPostingCard/style.ts
+++ b/src/components/corporate/JobPostingCard/style.ts
@@ -10,6 +10,9 @@ const Card = styled.article`
   height: 227px;
   padding: 26px 49px 29px 26px;
   margin-bottom: 18px;
+  &:hover {
+    background: #212121;
+  }
   /* 태블릿 뷰 */
   @media (max-width: 1199px) and (min-width: 766px) {
     margin-bottom: 4px;

--- a/src/views/SopticlePage/components/Sopticles/style.ts
+++ b/src/views/SopticlePage/components/Sopticles/style.ts
@@ -141,6 +141,9 @@ export const Title = styled.div`
     font-size: 20px;
   }
   ${textSingularLineEllipsis}
+  ${Card}:hover & {
+    opacity: 0.8;
+  }
 `;
 
 export const Desc = styled.div`


### PR DESCRIPTION
## Summary
- [x] 헤더의 지원하기 버튼
- [x] 솝티클 페이지의 솝티클 카드
- [x] 후원 페이지의 후원 카드

위 세가지 컴포넌트에 호버 상태를 추가합니다


## Screenshot
|지원하기버튼|솝티클카드|후원카드|
|-|-|-|
|![2023-06-22 09 12 54](https://github.com/sopt-makers/sopt.org-frontend/assets/48249505/6e2bc5f7-616a-4ea1-b2f8-f2143bc51b62)|![2023-06-22 09 13 31](https://github.com/sopt-makers/sopt.org-frontend/assets/48249505/1973bb1b-0ee8-4e02-9f1e-87e3699aefd7)|![2023-06-22 09 15 07](https://github.com/sopt-makers/sopt.org-frontend/assets/48249505/713d9d47-e11e-4003-ae27-43c9449fb772)|


## Comment
솝티클카드에게 효과를 줄 때, 호버된 부모의 자식에게 적용하는 방법을 보다가 (자식 선택자를 `nth-child`나 `div`/`p` 등으로 쓰는건 nono..), https://stackoverflow.com/questions/41007060/target-another-styled-component-on-hover 이 글을 발견하여 여기 있는대로 해 보았습니다. 

```ts
const Wrapper = styled.div`
  &:hover ${Button} {
    display: none;
  }
`
```

```ts
const Button = styled.button`
  ${Wrapper}:hover & {
    display: none;
  }
`;
```

그 과정에서 babel 플러그인을 설치하게 되었어요 !!  이것 괜찮으실지 의견 부탁딃니다~