### PR TITLE
feat: show DO SOPT in about tab

### DIFF
--- a/src/lib/api/remote/about.ts
+++ b/src/lib/api/remote/about.ts
@@ -15,34 +15,37 @@ const client = axios.create({
   timeout: DEFAULT_TIMEOUT,
 });
 
+const CURRENT_GENERATION = 33;
+
 const getAboutInfo = async (): Promise<GetAboutInfoResponse> => {
-  const { data } = await client.get('/aboutsopt');
+  const { data: dataCurrent } = await client.get(`/aboutsopt?generation=${CURRENT_GENERATION}`);
+  const { data: dataPrev } = await client.get(`/aboutsopt?generation=${CURRENT_GENERATION - 1}`);
 
   return {
     aboutInfo: {
-      generation: data.aboutSopt.id,
-      title: data.aboutSopt.title,
-      bannerImage: data.aboutSopt.bannerImage,
+      generation: dataCurrent.aboutSopt.id,
+      title: dataCurrent.aboutSopt.title,
+      bannerImage: dataCurrent.aboutSopt.bannerImage,
       coreValue: {
-        mainDescription: data.aboutSopt.coreDescription,
-        eachValues: data.aboutSopt.coreValues.map((coreValue: CoreValueResponseDto) => ({
+        mainDescription: dataCurrent.aboutSopt.coreDescription,
+        eachValues: dataCurrent.aboutSopt.coreValues.map((coreValue: CoreValueResponseDto) => ({
           title: coreValue.title,
           description: coreValue.subTitle,
           src: coreValue.imageUrl,
         })),
       },
       curriculums: {
-        [Part.PLAN]: data.aboutSopt.planCurriculum,
-        [Part.DESIGN]: data.aboutSopt.designCurriculum,
-        [Part.ANDROID]: data.aboutSopt.androidCurriculum,
-        [Part.IOS]: data.aboutSopt.iosCurriculum,
-        [Part.SERVER]: data.aboutSopt.serverCurriculum,
-        [Part.WEB]: data.aboutSopt.webCurriculum,
+        [Part.PLAN]: dataCurrent.aboutSopt.planCurriculum,
+        [Part.DESIGN]: dataCurrent.aboutSopt.designCurriculum,
+        [Part.ANDROID]: dataCurrent.aboutSopt.androidCurriculum,
+        [Part.IOS]: dataCurrent.aboutSopt.iosCurriculum,
+        [Part.SERVER]: dataCurrent.aboutSopt.serverCurriculum,
+        [Part.WEB]: dataCurrent.aboutSopt.webCurriculum,
       },
       records: {
-        memberCount: data.activitiesRecords.activitiesMemberCount,
-        projectCount: data.activitiesRecords.projectCounts,
-        studyCount: data.activitiesRecords.studyCounts,
+        memberCount: dataPrev.activitiesRecords.activitiesMemberCount,
+        projectCount: dataPrev.activitiesRecords.projectCounts,
+        studyCount: dataPrev.activitiesRecords.studyCounts,
       },
     },
   };

--- a/src/views/AboutPage/components/Member/Section/index.tsx
+++ b/src/views/AboutPage/components/Member/Section/index.tsx
@@ -16,7 +16,7 @@ const MemberSection = ({ generation }: MemberSectionProps) => {
     >
       {/* member 2뎁스 탭  개발 이 삭제 필요 */}
       <ScrollGhost id="members" />
-      <SectionTitle>{generation}기 활동 멤버들</SectionTitle>
+      <SectionTitle>{generation - 1}기 활동 멤버들</SectionTitle>
       <MemberContent />
     </Flex>
   );

--- a/src/views/AboutPage/components/Record/Section/index.tsx
+++ b/src/views/AboutPage/components/Record/Section/index.tsx
@@ -8,7 +8,7 @@ type RecordSectionProps = Pick<AboutInfoType, 'generation' | 'records'>;
 const RecordSection = (props: RecordSectionProps) => {
   return (
     <Flex dir="column" gap={{ mobile: 24, tablet: 48, desktop: 64 }}>
-      <SectionTitle>{props.generation}기 활동 레코드</SectionTitle>
+      <SectionTitle>{props.generation - 1}기 활동 레코드</SectionTitle>
       <RecordList records={props.records} />
     </Flex>
   );


### PR DESCRIPTION
## Summary
기존에는 about 탭에서 32기의 정보를 보여주고 있었는데, 33기 정보로 교체합니다.

## Screenshot
<img width="898" alt="image" src="https://github.com/sopt-makers/sopt.org-frontend/assets/48249505/bb7a9c97-2ea8-4122-add7-6d063b30f763">
