### PR TITLE
fix: project description's white-space

### DIFF
--- a/src/views/ProjectDetailPage/ProjectDetail.style.tsx
+++ b/src/views/ProjectDetailPage/ProjectDetail.style.tsx
@@ -363,6 +363,7 @@ export const ProjectDescription = styled(CommonWrapper)`
   border-radius: 10px;
   background-color: transparent;
   padding: 40px;
+  white-space: pre-wrap;
   /* 태블릿 뷰 */
   @media (max-width: 1280px) {
     width: 346px;


### PR DESCRIPTION
## Summary
프로젝트 설명 부분에 white-space: pre-wrap 속성을 추가합니다!

## Screenshot
<img width="1408" alt="image" src="https://github.com/sopt-makers/sopt.org-frontend/assets/48249505/b7fcc2b4-8933-4fa9-9e27-95de45b9e262">


## Comment
이미 배포버전엔 반영되었어요 ..

머지할 땐 feat/#153-recruit 먼저 머지한 후, 
이 PR의 base브랜치를 develop으로 바꾸어 rebase 머지할 계획입니다!