### PR TITLE
[SP0] 프로젝트 이미지 눌림 이슈

### DIFF
--- a/src/views/ProjectPage/components/project/ProjectCard.tsx
+++ b/src/views/ProjectPage/components/project/ProjectCard.tsx
@@ -1,3 +1,4 @@
+import styled from '@emotion/styled';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useIsDesktop, useIsMobile, useIsTablet } from '@src/hooks/useDevice';
@@ -58,11 +59,9 @@ function ProjectCardMobileImage(logoImage: string, thumbnailImage?: string) {
   return (
     <>
       {isCardThumbnail && (
-        <Image
+        <StyledThumbnail
           className={`${GTM_CLASS.projectCard}`}
           src={thumbnailImage}
-          width={316}
-          height={176}
           alt="thumbnail"
         />
       )}
@@ -78,6 +77,12 @@ function ProjectCardMobileImage(logoImage: string, thumbnailImage?: string) {
     </>
   );
 }
+
+const StyledThumbnail = styled.img`
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+`;
 
 function ProjectCardDesktopImage(logoImage: string, thumbnailImage?: string) {
   const isCardThumbnail = thumbnailImage && thumbnailImage?.length > 0;

--- a/src/views/ProjectPage/components/project/project-card.module.scss
+++ b/src/views/ProjectPage/components/project/project-card.module.scss
@@ -30,7 +30,7 @@
 
     @include desktop {
       width: 368px;
-      height: 208px;
+      height: 270px;
       margin: 7px;
       padding-bottom: 5px;
 
@@ -41,7 +41,7 @@
 
     @include mobile-tablet {
       width: 316px;
-      height: 176px;
+      height: 235px;
       margin: 5px;
       padding-bottom: 5px;
 


### PR DESCRIPTION
## Summary
close #165 
`object-fit : cover` 속성을 부여했습니다.
## Screenshot
|전|후|이미지 16:9 ration 조정|
|--|--|--|
|<img width="356" alt="image" src="https://github.com/sopt-makers/sopt.org-frontend/assets/62867581/7d463257-dad1-4255-9670-a7ceabdd062a">|<img width="348" alt="image" src="https://github.com/sopt-makers/sopt.org-frontend/assets/62867581/1b3c1a3a-6818-482a-a156-b6d860e2a517">|<img width="364" alt="image" src="https://github.com/sopt-makers/sopt.org-frontend/assets/62867581/bf81bace-7b57-414e-84ac-b6c2d17b02a7">|


## Comment
공홈(176px)과 플레이그라운드와는 높이(208px)가 달라서 이미지 중 일부 보이지 않는 부분이 있을 수는 있습니다. 추후 개편때 디자이너분과 얘기를 해보면 좋을 것 같아요
