### PR TITLE
[SP0] 프로젝트 링크 넘침 이슈

### DIFF
--- a/src/views/ProjectPage/components/project/ProjectCard.tsx
+++ b/src/views/ProjectPage/components/project/ProjectCard.tsx
@@ -28,7 +28,7 @@ export function ProjectCard({ project }: { project: ProjectType }) {
           </div>
           <div className={`${styles.links} ${GTM_CLASS.projectCard}`}>
             {project.link
-              ?.filter(({ title }) => title?.length > 0)
+              ?.filter((project, index) => project?.title?.length > 0 && index <= 3)
               .map(({ title, url }) => {
                 return <div key={shortid.generate()}>{LinkRender(title, url)}</div>;
               })}


### PR DESCRIPTION
## Summary
close #164 
링크가 4개가 넘어가면 링크에서 넘치는 이슈가 발생해 index 3번째 링크 요소까지만 보여지도록 임시로 설정해두었습니다.
## Screenshot
<img width="776" alt="image" src="https://github.com/sopt-makers/sopt.org-frontend/assets/62867581/fe3d3e5e-2d85-4185-a9b7-f9c77467b55f">


## Comment
추후에 넘치는 링크 요소들을 어떻게 처리할지는 논의가 필요합니다!