### PR TITLE
[SP1] 솝티클 썸네일 이미지 찌부 이슈

### DIFF
--- a/src/views/MainPage/components/ActivityDescription/ActivityDescription.tsx
+++ b/src/views/MainPage/components/ActivityDescription/ActivityDescription.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+import React from 'react';
 import { useIsDesktop, useIsMobile, useIsTablet } from '@src/hooks/useDevice';
 import { useTabs } from '@src/hooks/useTabs';
 import {
@@ -134,8 +135,12 @@ function MobileActivityDescription() {
         </div>
         <div className={styles.cardContent}>
           <p>
-            {currentTab.content.map(({ data, highlight }) =>
-              highlight ? <span>{data}</span> : data,
+            {currentTab.content.map(({ data, highlight }, index) =>
+              highlight ? (
+                <span key={index}>{data}</span>
+              ) : (
+                <React.Fragment key={index}>{data}</React.Fragment>
+              ),
             )}
           </p>
         </div>
@@ -165,7 +170,13 @@ function DesktopActivityDescription() {
             </div>
             <div className={styles.cardContent}>
               <p>
-                {content.map(({ data, highlight }) => (highlight ? <span>{data}</span> : data))}
+                {content.map(({ data, highlight }, index) =>
+                  highlight ? (
+                    <span key={index}>{data}</span>
+                  ) : (
+                    <React.Fragment key={index}>{data}</React.Fragment>
+                  ),
+                )}
               </p>
             </div>
           </article>

--- a/src/views/SopticlePage/components/Sopticles/style.ts
+++ b/src/views/SopticlePage/components/Sopticles/style.ts
@@ -95,7 +95,9 @@ export const ThumbnailWrapper = styled.div`
   }
 `;
 
-export const Thumbnail = styled(Image)``;
+export const Thumbnail = styled(Image)`
+  object-fit: cover;
+`;
 
 export const ChipWrapper = styled.div`
   display: flex;


### PR DESCRIPTION
## Summary
close #174 
솝티클 썸네일 이미지 찌부 이슈를 해결했습니다.

## Screenshot

|전|후|
|--|--|
|<img width="1356" alt="image" src="https://github.com/sopt-makers/sopt.org-frontend/assets/62867581/06f0b04d-8cfb-4edc-a767-30527007c5d8">|<img width="1333" alt="image" src="https://github.com/sopt-makers/sopt.org-frontend/assets/62867581/827f353d-a8dc-43df-a058-d7fea3889f07">|

## Comment
<img width="1198" alt="스크린샷 2023-09-15 오전 11 07 03" src="https://github.com/sopt-makers/sopt.org-frontend/assets/62867581/335cd9e4-7863-4329-8e04-cf8003dcaf27">
메인페이지 ActivityDescription 부분에서 key가 없어서 CI가 실패하는 에러가 났어요! 서진이 `폴더구조 변경 리팩토링 PR` 에서 해당 커밋을 본 기억이 있어서 똑같이 작업했습니다! 다만,,,  data가 {data}로 되어있지 않아서 data 그대로 출력되는 오류가 있어서 이부분을 수정해 작업했고, 서진이 pr에도 언급해두었습니다!!