### PR TITLE
[SP-1] 프로젝트 탭의 필터 모양을 다른 탭과 동일하게 수정

### DIFF
--- a/src/assets/icons/arrow_right_24x24.svg
+++ b/src/assets/icons/arrow_right_24x24.svg
@@ -1,3 +1,3 @@
 <svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M10 19L15.8215 13.1785C16.4724 12.5276 16.4724 11.4724 15.8215 10.8215L10 5" stroke="white" stroke-opacity="0.5" stroke-width="1.66667" stroke-linecap="round"/>
+<path d="M10 19L15.8215 13.1785C16.4724 12.5276 16.4724 11.4724 15.8215 10.8215L10 5" stroke="white" stroke-width="1.66667" stroke-linecap="round"/>
 </svg>

--- a/src/views/ProjectPage/ProjectPage.tsx
+++ b/src/views/ProjectPage/ProjectPage.tsx
@@ -1,6 +1,8 @@
+import styled from '@emotion/styled';
 import { useState } from 'react';
 import { Footer, Header, Layout, ScrollToTopButton } from '@src/components';
 import { ProjectCategoryType } from '@src/lib/types/project';
+import { mainColor } from '@src/styles/colors';
 import { ProjectFilter, ProjectList } from './components';
 import useFetch from './hooks/useFetch';
 
@@ -12,11 +14,59 @@ function Projects() {
     <Layout>
       <Header />
       <ScrollToTopButton />
-      <ProjectFilter selectedCategory={selectedCategory} setCategory={setCategory} />
-      <ProjectList state={state} selectedCategory={selectedCategory} />
+      <Root>
+        <Title>프로젝트</Title>
+        <ProjectFilter selectedCategory={selectedCategory} setCategory={setCategory} />
+        <ProjectList state={state} selectedCategory={selectedCategory} />
+      </Root>
       <Footer />
     </Layout>
   );
 }
+
+const Root = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 1200px;
+  min-height: 100vh;
+  margin: 0 auto;
+
+  /* 태블릿 뷰 */
+  @media (max-width: 1199px) and (min-width: 766px) {
+    width: 700px;
+    margin-top: 90px;
+  }
+  /* 모바일 뷰 */
+  @media (max-width: 765.9px) {
+    width: 360px;
+    margin-top: 90px;
+  }
+`;
+
+const Title = styled.div`
+  font-weight: 700;
+  color: ${mainColor.white};
+  text-align: center;
+
+  /* 데스크탑 뷰 */
+  @media (min-width: 1124px) {
+    margin-top: 190px;
+    margin-bottom: 54px;
+    font-size: 40px;
+  }
+
+  /* 태블릿 뷰 */
+  @media (max-width: 1123px) {
+    margin-top: 70px;
+    margin-bottom: 52px;
+    font-size: 36px;
+  }
+
+  /* 태블릿 뷰 */
+  @media (max-width: 765.9px) {
+    margin-top: 32px;
+    font-size: 20px;
+  }
+`;
 
 export default Projects;

--- a/src/views/ProjectPage/components/filter/ProjectFilter.tsx
+++ b/src/views/ProjectPage/components/filter/ProjectFilter.tsx
@@ -1,24 +1,63 @@
+import styled from '@emotion/styled';
 import { Dispatch, SetStateAction } from 'react';
-import { useIsDesktop, useIsMobile, useIsTablet } from '@src/hooks/useDevice';
 import { ProjectCategoryType } from '@src/lib/types/project';
-import { DesktopFilter } from './DesktopFilter';
-import { MobileFilter } from './MobileFilter';
 
 interface ProjectFilterPropType {
   selectedCategory: ProjectCategoryType;
   setCategory: Dispatch<SetStateAction<ProjectCategoryType>>;
 }
 
-export function ProjectFilter({ selectedCategory, setCategory }: ProjectFilterPropType) {
-  const isDesktop = useIsDesktop();
-  const isTablet = useIsTablet();
-  const isMobile = useIsMobile();
+const tabs = [
+  { value: ProjectCategoryType.ALL, label: '전체' },
+  { value: ProjectCategoryType.APPJAM, label: '앱잼' },
+  { value: ProjectCategoryType.SOPKATHON, label: '솝커톤' },
+  { value: ProjectCategoryType.SOPTERM, label: '솝텀프로젝트' },
+  { value: ProjectCategoryType.STUDY, label: '스터디' },
+  { value: ProjectCategoryType.JOINTSEMINAR, label: '합동세미나' },
+  { value: ProjectCategoryType.ETC, label: '기타' },
+];
 
+export function ProjectFilter({ selectedCategory, setCategory }: ProjectFilterPropType) {
   return (
-    <>
-      {isDesktop && <DesktopFilter selectedCategory={selectedCategory} setCategory={setCategory} />}
-      {isTablet && <MobileFilter selectedCategory={selectedCategory} setCategory={setCategory} />}
-      {isMobile && <MobileFilter selectedCategory={selectedCategory} setCategory={setCategory} />}
-    </>
+    <TabBar>
+      {tabs.map((tab) => (
+        <Tab
+          key={tab.value}
+          onClick={() => setCategory(tab.value)}
+          selected={selectedCategory === tab.value}
+        >
+          {tab.label}
+        </Tab>
+      ))}
+    </TabBar>
   );
 }
+
+export const TabBar = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 12px;
+`;
+
+export const Tab = styled.div<{ selected: boolean }>`
+  cursor: pointer;
+  text-align: center;
+  padding: 20px 0;
+  border-radius: 10px;
+  color: ${({ selected }) => (selected ? '#FFFFFF' : '#cccccc')};
+  background-color: ${({ selected }) => (selected ? '#FFFFFF1A' : 'inherit')};
+  font-size: 18px;
+
+  min-width: 160px;
+  &:hover {
+    background-color: rgba(255, 255, 255, 0.1);
+  }
+
+  /* 태블릿 뷰 */
+  @media (max-width: 765.9px) {
+    min-width: 72px;
+    padding: 12px 0;
+    font-size: 12px;
+  }
+`;

--- a/src/views/ProjectPage/components/project/ProjectList.tsx
+++ b/src/views/ProjectPage/components/project/ProjectList.tsx
@@ -84,7 +84,7 @@ function ProjectCardList(list: ProjectType[]) {
 function ProjectListCount(count: number) {
   return (
     <div className={styles['list-count']}>
-      <div>{count} 개의 프로젝트가 있어요.</div>
+      <div>{count}개의 프로젝트</div>
     </div>
   );
 }

--- a/src/views/ProjectPage/components/project/project-enroll.module.scss
+++ b/src/views/ProjectPage/components/project/project-enroll.module.scss
@@ -5,17 +5,22 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  color: rgba(255, 255, 255, 0.5);
+  color: #ffffff;
   font-style: normal;
 
   .content {
-    width: 60%;
     display: flex;
     justify-content: center;
     align-items: center;
 
-    padding-top: 5px;
     cursor: pointer;
+    color: #ffffff;
+    background-color: #504ebf;
+    border-radius: 30px;
+    padding: 12px 20px;
+    &:hover {
+      background-color: #413fac;
+    }
   }
 
   @include desktop {
@@ -23,14 +28,12 @@
     p {
       font-size: 22px;
       font-weight: 500;
-      color: rgba(255, 255, 255, 0.5);
       padding-bottom: 10px;
     }
 
     span {
       font-size: 22px;
       font-weight: 700;
-      color: rgba(255, 255, 255, 0.5);
     }
   }
 
@@ -40,14 +43,12 @@
     p {
       font-size: 15px;
       font-weight: 500;
-      color: rgba(255, 255, 255, 0.5);
       padding-bottom: 10px;
     }
 
     span {
       font-size: 15px;
       font-weight: 700;
-      color: rgba(255, 255, 255, 0.5);
     }
   }
 }

--- a/src/views/ProjectPage/components/project/project-list.module.scss
+++ b/src/views/ProjectPage/components/project/project-list.module.scss
@@ -23,13 +23,11 @@ list-container는 description, count, card-list 영역을 가짐.
   @include desktop {
     height: 100%;
     width: 100%;
-    margin-top: 130px;
   }
 
   @include mobile-tablet {
     height: 100%;
     width: 100%;
-    margin-top: 190px;
   }
 }
 
@@ -41,7 +39,6 @@ list-container는 description, count, card-list 영역을 가짐.
   height: 160px;
   background: linear-gradient(90deg, #000000 1.33%, rgba(0, 0, 0, 0) 100%);
   border-radius: 10px;
-  margin-bottom: 80px;
 
   p {
     display: flex;
@@ -64,10 +61,14 @@ list-container는 description, count, card-list 영역을 가짐.
 
   @include desktop {
     width: 100%;
+    margin-top: 36px;
+    margin-bottom: 36px;
   }
 
   @include tablet-medium {
     width: 90%;
+    margin-top: 36px;
+    margin-bottom: 36px;
 
     p {
       font-weight: 500;
@@ -81,7 +82,9 @@ list-container는 description, count, card-list 영역을 가짐.
   }
 
   @include tablet-small {
-    width: 75%;
+    width: 662px;
+    margin-top: 36px;
+    margin-bottom: 36px;
     p {
       font-weight: 500;
       font-size: 20px;
@@ -96,6 +99,8 @@ list-container는 description, count, card-list 영역을 가짐.
   @include mobile {
     width: 90%;
     height: 130px;
+    margin-top: 16px;
+    margin-bottom: 16px;
 
     p {
       font-style: normal;
@@ -128,29 +133,34 @@ list-container는 description, count, card-list 영역을 가짐.
   display: flex;
   align-items: center;
   justify-content: center;
-  margin-bottom: 80px;
-  padding-top: 40px;
 
   & > div {
     display: flex;
-    justify-content: center;
-    width: 100%;
+    justify-content: flex-end;
+    width: 90%;
 
-    color: rgba(255, 255, 255, 0.3);
-    font-size: 32px;
+    color: #8e8e8e;
+    font-size: 18px;
+    line-height: 26px;
     font-weight: 500;
     opacity: 30%;
+    padding-bottom: 22px;
+
+    @include tablet-medium {
+      width: 90%;
+    }
 
     @include tablet-small {
-      font-size: 28px;
-      padding-left: 0;
+      width: 662px;
     }
 
     @include mobile {
+      width: 90%;
       font-style: normal;
       font-weight: 500;
-      font-size: 18px;
+      font-size: 12px;
       padding: 0;
+      padding-bottom: 12px;
     }
   }
 }
@@ -172,7 +182,7 @@ list-container는 description, count, card-list 영역을 가짐.
 
   @include tablet-small {
     grid-template-columns: 1fr 1fr;
-    width: 75%;
+    width: 662px;
     gap: 20px;
   }
 


### PR DESCRIPTION
## Summary
프로젝트 탭 필터를 다른 탭과 같은 형식으로 변경한 작업입니다!
이전 디자이너이신 채량언니가 안을 주고 가셔서 작업한 내용이에요~
https://sopt-org-frontend-git-feat-152project-tab-filter-seojinseojin.vercel.app/project
여기서 사용해 보실 수 있으십니다!

## Screenshot
<img width="1422" alt="image" src="https://github.com/sopt-makers/sopt.org-frontend/assets/48249505/f65a29db-693f-4be5-8056-1fddf561cb92">

## Comment
스프린트 -1에 진행했는데 이제야 PR을 올립니다 ...
코드 뿐만 아니라 UI 관해서도 의견 주시면 감사하겠습니다!!
