### PR TITLE
[SP1] 솝트 회칙 페이지 컬러 변경

### DIFF
--- a/src/views/RulesPage/components/UnderlinedText/UnderlinedText.style.tsx
+++ b/src/views/RulesPage/components/UnderlinedText/UnderlinedText.style.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import { TitleProps } from './UnderlinedText';
 
 export const Root = styled.h1<TitleProps>`
-  border-bottom: 10px solid ${({ theme }) => theme.colors.soptWhite};
+  border-bottom: 10px solid #fcfcfc;
   padding-bottom: 10px;
 
   width: max-content;
@@ -14,7 +14,7 @@ export const Root = styled.h1<TitleProps>`
   font-weight: 800;
 
   @media (max-width: 1279px) {
-    border-bottom: 6px solid ${({ theme }) => theme.colors.soptWhite};
+    border-bottom: 6px solid #fcfcfc;
     padding-bottom: 5px;
 
     line-height: 31px;

--- a/src/views/RulesPage/components/UnderlinedText/UnderlinedText.style.tsx
+++ b/src/views/RulesPage/components/UnderlinedText/UnderlinedText.style.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import { TitleProps } from './UnderlinedText';
 
 export const Root = styled.h1<TitleProps>`
-  border-bottom: 10px solid ${({ theme }) => theme.colors.mainColor};
+  border-bottom: 10px solid ${({ theme }) => theme.colors.soptWhite};
   padding-bottom: 10px;
 
   width: max-content;
@@ -14,7 +14,7 @@ export const Root = styled.h1<TitleProps>`
   font-weight: 800;
 
   @media (max-width: 1279px) {
-    border-bottom: 6px solid ${({ theme }) => theme.colors.mainColor};
+    border-bottom: 6px solid ${({ theme }) => theme.colors.soptWhite};
     padding-bottom: 5px;
 
     line-height: 31px;


### PR DESCRIPTION
## Summary
close #186 
회칙 페이지에 블루 컬러가 사용되어서 #fcfcfc 색상으로 변경했습니다!

## Screenshot
|전|후|
|--|--|
|<img width="491" alt="image" src="https://github.com/sopt-makers/sopt.org-frontend/assets/62867581/ff5ca30b-42a0-4d59-a5b7-3ccf8d28e18a">|<img width="477" alt="image" src="https://github.com/sopt-makers/sopt.org-frontend/assets/62867581/6b143c73-c188-4c0d-8b87-a7eedc0d8b21">|

## Comment
