### PR TITLE
[SP1] 활동후기 페이지 요청 많이 가는 에러 수정

### DIFF
--- a/src/hooks/useStackedFetchBase/index.ts
+++ b/src/hooks/useStackedFetchBase/index.ts
@@ -1,6 +1,5 @@
 import { to } from 'await-to-js';
 import { useEffect, useReducer } from 'react';
-import { debounce } from '@src/utils/debounce';
 import { reducer } from './reducer';
 import { Action, State } from './types';
 
@@ -14,7 +13,7 @@ function useStackedFetchBase<T>(
   });
 
   useEffect(() => {
-    const fetchList = debounce(async () => {
+    const fetchList = async () => {
       dispatch({
         _TAG: 'FETCH',
         isInitialFetching,
@@ -32,7 +31,7 @@ function useStackedFetchBase<T>(
       if (response) {
         dispatch({ _TAG: 'SUCCESS', isInitialFetching, data: response });
       }
-    });
+    };
 
     fetchList();
   }, [willFetch, isInitialFetching]);

--- a/src/views/ReviewPage/hooks/useFetch.ts
+++ b/src/views/ReviewPage/hooks/useFetch.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import useBooleanState from '@src/hooks/useBooleanState';
 import useStackedFetchBase from '@src/hooks/useStackedFetchBase';
 import { api } from '@src/lib/api';
@@ -6,13 +6,26 @@ import { ExtraPart } from '@src/lib/types/universal';
 import useInfiniteScroll from './useInfiniteScroll';
 
 const useFetch = (selected: ExtraPart) => {
-  const { ref, count, setCount } = useInfiniteScroll();
+  const jobRecordRef = useRef<Record<number, 'QUEUED' | 'DONE'>>({});
+  const isIncrementable = () =>
+    Object.values(jobRecordRef.current).every((value) => value === 'DONE');
+
+  const { ref, count, setCount } = useInfiniteScroll(isIncrementable);
   const [canGetMoreReviews, setCanGetMoreReviews, setCanNotGetMoreReviews] = useBooleanState(true);
+
+  useEffect(() => {
+    jobRecordRef.current[count] = 'QUEUED';
+  }, [count]);
 
   useEffect(() => {
     function initializeStates() {
       setCount(1);
       setCanGetMoreReviews();
+      for (const key in jobRecordRef.current) {
+        if (Object.hasOwnProperty.call(jobRecordRef.current, key)) {
+          delete jobRecordRef.current[key];
+        }
+      }
     }
     return () => {
       initializeStates();
@@ -23,6 +36,7 @@ const useFetch = (selected: ExtraPart) => {
     setCanNotGetMoreReviews();
     const response = await api.reviewAPI.getReviews(selected, count);
     response.hasNextPage ? setCanGetMoreReviews() : setCanNotGetMoreReviews();
+    jobRecordRef.current[count] = 'DONE';
     return response.reviews;
   }, [selected, count, setCanGetMoreReviews, setCanNotGetMoreReviews]);
   const state = useStackedFetchBase(willFetch, count === 1);

--- a/src/views/ReviewPage/hooks/useInfiniteScroll.ts
+++ b/src/views/ReviewPage/hooks/useInfiniteScroll.ts
@@ -1,12 +1,14 @@
 import { useState } from 'react';
 import useIntersectionObserver from '@src/hooks/useIntersectionObserver';
 
-export default function useInfiniteScroll() {
+export default function useInfiniteScroll(isIncrementable: () => boolean) {
   const [count, setCount] = useState(1);
 
   const ref = useIntersectionObserver(
     async (entry, observer) => {
-      setCount((prevCount) => prevCount + 1);
+      if (isIncrementable()) {
+        setCount((prevCount) => prevCount + 1);
+      }
       observer.unobserve(entry.target);
     },
     { rootMargin: '80px' },


### PR DESCRIPTION
- close #190 
## Summary
### 에러가 발생한 이유
원래 아래 경우를 가정하고 코드를 짰습니다.
1. 1페이지 요청 보내기 (status: loading)
2. 1페이지 응답 받기 (status: ok)
3. 2페이지 요청 보내기 (status: loading)
4. 2페이지 응답 받기 (status: ok)

...
그래서 loading일 때는 요청을 안 보내고, ok일 때만 요청을 보낼 수 있도록,
ok인 상황에서만 무한 스크롤 페이저의 count가 증가되도록 코드를 짜 두었어요

However....
실제 경우에는 이렇게 된거죵 ..
1. 1페이지 요청 보내기 (status: loading)
2. 2페이지 요청 보내기 (status: loading)
3. 1페이지 응답 받기 (status: ok)

그럼 2페이지 요청이 진행중인데도 status가 ok라서 다음 페이지들에게도 요청이 간 것입니다!

### 해결 방법
제 뇌피셜이라 좋은 코드는 아닐지도 몰라요  ..!!
마음껏 피드백 주셔용

**1. jobRecordRef 이라는 ref를 만듭니다. (ref인 이유는 state로 쓰기 싫어서 입니다)**
```ts
const jobRecordRef = useRef<Record<number, 'QUEUED' | 'DONE'>>({});
```
여기서는 코드가 
1. 1페이지 요청 보내기 (status: loading)
2. 2페이지 요청 보내기 (status: loading)
3. 1페이지 응답 받기 (status: ok)
이 상황처럼 꼬이더라도, 아래와 같이 저장됩니다.
```ts
// 위 상황에서 jobRecodRef.current 에 저장된 값
{ 1 : 'DONE', 2 : 'QUEUED' };
```

**2. isIncrementable 이라는 함수를 만들어서, 현재 요청들이 다 처리되었는지 확인합니다.**
```ts
  const isIncrementable = () =>
    Object.values(jobRecordRef.current).every((value) => value === 'DONE');
```
이 값을 infinite scroll 하는 훅에 넘겨서 , isIncrementable이 false면  (하나라도 'DONE'이 아니면) count를 증가시키지 않습니다.

## Comment
아님 아예 집합 형식으로 만들어서, 
1. 1페이지 요청 보내기 - [1]
2. 2페이지 요청 보내기 - [1, 2]
3. 1페이지 응답 받기 - [2]
4. 2페이지 응답 받기  - [ ]

이런 식으로 하고, 작업중인게 비어 있으면 요청을 보내지 않도록 해도 괜찮을 것 같기도 합니다 ..!! 