### PR TITLE
[SP1] 리크루팅 알림받기 API에서 500 에러가 나는 것을 해결한다.

### DIFF
--- a/src/lib/constants/googlesheet-env.ts
+++ b/src/lib/constants/googlesheet-env.ts
@@ -2,7 +2,7 @@ export const googleSheetCredential = {
   type: 'service_account',
   project_id: process.env.NEXT_GOOGLE_SHEET_PROJECT_ID,
   private_key_id: process.env.NEXT_GOOGLE_SHEET_PRIVATE_KEY_ID,
-  private_key: process.env.NEXT_GOOGLE_SHEET_PRIVATE_KEY,
+  private_key: process.env.NEXT_GOOGLE_SHEET_PRIVATE_KEY?.split(String.raw`\n`).join('\n'),
   client_email: process.env.NEXT_GOOGLE_SHEET_CLIENT_EMAIL,
   client_id: process.env.NEXT_GOOGLE_SHEET_CLIENT_ID,
   auth_uri: process.env.NEXT_GOOGLE_SHEET_AUTH_URI,

--- a/src/pages/api/register.ts
+++ b/src/pages/api/register.ts
@@ -9,7 +9,7 @@ export default async function handler(request: NextApiRequest, response: NextApi
       return response.status(200).json({ success: resultStatus === 200, resultStatus });
     }
   } catch (error) {
-    return response.status(500).json({ error: 'Internal server error' });
+    return response.status(500).json({ error });
   }
 
   return response.status(200).json({ success: true });


### PR DESCRIPTION
- close #192 

## Summary
구글시트에서 뭔가 정책을 바꿔서, private key에 있는 \n에 대해 특별한 처리를 해주지 않으면 에러가 나게 되었스빈다..
https://stackoverflow.com/questions/74131595/error-error1e08010cdecoder-routinesunsupported-with-google-auth-library
22일 전에 올라온걸 보니 따끈따끈한 이슈인 것 같긴 한데, 왜 그동안 잘 됐던 걸까요 ..?
