### PR TITLE
feat : head 태그 컴포넌트로 분리 및 프로젝트별 og tag 적용

### DIFF
--- a/src/components/common/HTMLHead/index.tsx
+++ b/src/components/common/HTMLHead/index.tsx
@@ -1,13 +1,13 @@
 import Head from 'next/head';
 
 interface HeadProps {
-  title?: string;
+  projectTitle?: string;
   projectID?: string;
-  imageURL?: string;
+  projectImageURL?: string;
 }
 
 function HTMLHead(props: HeadProps) {
-  const { title, projectID, imageURL } = props;
+  const { projectTitle, projectID, projectImageURL } = props;
 
   return (
     <Head>
@@ -66,13 +66,13 @@ function HTMLHead(props: HeadProps) {
         property="og:url"
         content={`https://sopt.org/project/${projectID}` || 'https://sopt.org/'}
       />
-      <meta property="og:title" content={`SOPT 프로젝트 ${title}` || 'SOPT'} />
+      <meta property="og:title" content={`SOPT 프로젝트 ${projectTitle}` || 'SOPT'} />
       <meta property="og:site_name" content="SOPT 공식 홈페이지" />
       <meta property="og:description" content={'대학생 연합 IT 벤처 창업 동아리'} />
       <meta
         property="og:image"
         content={
-          imageURL ||
+          projectImageURL ||
           'https://s3.ap-northeast-2.amazonaws.com/sopt.org/admin/origin/img_sopt_homepage.png'
         }
       />

--- a/src/components/common/HTMLHead/index.tsx
+++ b/src/components/common/HTMLHead/index.tsx
@@ -1,0 +1,84 @@
+import Head from 'next/head';
+
+interface HeadProps {
+  title?: string;
+  projectID?: string;
+  imageURL?: string;
+}
+
+function HTMLHead(props: HeadProps) {
+  const { title, projectID, imageURL } = props;
+
+  return (
+    <Head>
+      <title>SOPT</title>
+      <meta
+        name="description"
+        content="SOPT는 IT와 벤처 창업에 뜻이 있는 대학생들이 모인 국내 최대 규모의 대학생 연합 IT 벤처 창업 동아리입니다."
+      />
+      <meta name="title" content="SOPT" />
+      <meta name="keyword" content="IT, 창업, 개발, 대학생, 동아리" />
+      <meta name="viewport" content="initial-scale=1.0, width=device-width" />
+
+      <meta name="apple-mobile-web-app-title" content="SOPT" />
+      <meta name="apple-mobile-web-app-capable" content="yes" />
+      <meta name="apple-mobile-web-app-status-bar-style" content="black" />
+
+      <link rel="apple-touch-icon" sizes="57x57" href="/apple-icon-57x57.png" />
+      <link rel="apple-touch-icon" sizes="60x60" href="/apple-icon-60x60.png" />
+      <link rel="apple-touch-icon" sizes="72x72" href="/apple-icon-72x72.png" />
+      <link rel="apple-touch-icon" sizes="76x76" href="/apple-icon-76x76.png" />
+      <link rel="apple-touch-icon" sizes="114x114" href="/apple-icon-114x114.png" />
+      <link rel="apple-touch-icon" sizes="120x120" href="/apple-icon-120x120.png" />
+      <link rel="apple-touch-icon" sizes="144x144" href="/apple-icon-144x144.png" />
+      <link rel="apple-touch-icon" sizes="152x152" href="/apple-icon-152x152.png" />
+      <link rel="apple-touch-icon" sizes="180x180" href="/apple-icon-180x180.png" />
+      <link rel="icon" type="image/png" sizes="192x192" href="/android-icon-192x192.png" />
+      <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+      <link rel="icon" type="image/png" sizes="96x96" href="/favicon-96x96.png" />
+      <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+
+      <link rel="manifest" href="/manifest.json" />
+      <meta name="msapplication-TileColor" content="#ffffff" />
+      <meta name="msapplication-TileImage" content="/ms-icon-144x144.png" />
+      <meta name="theme-color" content="#ffffff" />
+      <meta
+        name="viewport"
+        content="width=device-width, initial-scale=1.0, minimum-scale=1.0,  maximum-scale=1"
+      />
+      <meta content="yes" name="apple-mobile-web-app-capable" />
+
+      {/*  Twitter */}
+      <meta name="twitter:title" content="SOPT" />
+      <meta name="twitter:description" content="대학생 연합 IT 벤처 창업 동아리" />
+      <meta property="twitter:card" content="website" />
+      <meta property="twitter:site" content="https://sopt.org/" />
+      <meta
+        name="twitter:image"
+        content="https://s3.ap-northeast-2.amazonaws.com/sopt.org/admin/origin/img_sopt_homepage.png"
+      />
+      <meta property="twitter:image:alt" content="SOPT 공식 홈페이지 이미지" />
+
+      {/*  Open Graph */}
+      <meta property="og:type" content="website" />
+      <meta property="og:locale" content="ko_KR" />
+      <meta
+        property="og:url"
+        content={`https://sopt.org/project/${projectID}` || 'https://sopt.org/'}
+      />
+      <meta property="og:title" content={`SOPT 프로젝트 ${title}` || 'SOPT'} />
+      <meta property="og:site_name" content="SOPT 공식 홈페이지" />
+      <meta property="og:description" content={'대학생 연합 IT 벤처 창업 동아리'} />
+      <meta
+        property="og:image"
+        content={
+          imageURL ||
+          'https://s3.ap-northeast-2.amazonaws.com/sopt.org/admin/origin/img_sopt_homepage.png'
+        }
+      />
+      <meta property="og:image:alt" content="SOPT 공식 홈페이지 이미지" />
+    </Head>
+  );
+}
+
+export default HTMLHead;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,11 +1,11 @@
 import * as amplitude from '@amplitude/analytics-browser';
 import type { AppProps } from 'next/app';
-import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { Global, ThemeProvider } from '@emotion/react';
 import { useEffect } from 'react';
 import { useState } from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
+import HTMLHead from '@src/components/common/HTMLHead';
 import GoogleTagManagerNoscript from '@src/components/googleTagManager/Noscript';
 import GoogleTagManagerScript from '@src/components/googleTagManager/Script';
 import * as gtm from '@src/components/googleTagManager/gtm';
@@ -33,68 +33,7 @@ function MyApp({ Component, pageProps }: AppProps) {
 
   return (
     <>
-      <Head>
-        <title>SOPT</title>
-        <meta
-          name="description"
-          content="SOPT는 IT와 벤처 창업에 뜻이 있는 대학생들이 모인 국내 최대 규모의 대학생 연합 IT 벤처 창업 동아리입니다."
-        />
-        <meta name="title" content="SOPT" />
-        <meta name="keyword" content="IT, 창업, 개발, 대학생, 동아리" />
-        <meta name="viewport" content="initial-scale=1.0, width=device-width" />
-
-        <meta name="apple-mobile-web-app-title" content="SOPT" />
-        <meta name="apple-mobile-web-app-capable" content="yes" />
-        <meta name="apple-mobile-web-app-status-bar-style" content="black" />
-
-        <link rel="apple-touch-icon" sizes="57x57" href="/apple-icon-57x57.png" />
-        <link rel="apple-touch-icon" sizes="60x60" href="/apple-icon-60x60.png" />
-        <link rel="apple-touch-icon" sizes="72x72" href="/apple-icon-72x72.png" />
-        <link rel="apple-touch-icon" sizes="76x76" href="/apple-icon-76x76.png" />
-        <link rel="apple-touch-icon" sizes="114x114" href="/apple-icon-114x114.png" />
-        <link rel="apple-touch-icon" sizes="120x120" href="/apple-icon-120x120.png" />
-        <link rel="apple-touch-icon" sizes="144x144" href="/apple-icon-144x144.png" />
-        <link rel="apple-touch-icon" sizes="152x152" href="/apple-icon-152x152.png" />
-        <link rel="apple-touch-icon" sizes="180x180" href="/apple-icon-180x180.png" />
-        <link rel="icon" type="image/png" sizes="192x192" href="/android-icon-192x192.png" />
-        <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
-        <link rel="icon" type="image/png" sizes="96x96" href="/favicon-96x96.png" />
-        <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
-
-        <link rel="manifest" href="/manifest.json" />
-        <meta name="msapplication-TileColor" content="#ffffff" />
-        <meta name="msapplication-TileImage" content="/ms-icon-144x144.png" />
-        <meta name="theme-color" content="#ffffff" />
-        <meta
-          name="viewport"
-          content="width=device-width, initial-scale=1.0, minimum-scale=1.0,  maximum-scale=1"
-        />
-        <meta content="yes" name="apple-mobile-web-app-capable" />
-
-        {/*  Open Graph */}
-        <meta property="og:type" content="website" />
-        <meta property="og:locale" content="ko_KR" />
-        <meta property="og:url" content="https://sopt.org/" />
-        <meta property="og:title" content="SOPT" />
-        <meta property="og:site_name" content="SOPT 공식 홈페이지" />
-        <meta property="og:description" content="대학생 연합 IT 벤처 창업 동아리" />
-        <meta
-          property="og:image"
-          content="https://s3.ap-northeast-2.amazonaws.com/sopt.org/admin/origin/img_sopt_homepage.png"
-        />
-        <meta property="og:image:alt" content="SOPT 공식 홈페이지 이미지" />
-
-        {/*  Twitter */}
-        <meta name="twitter:title" content="SOPT" />
-        <meta name="twitter:description" content="대학생 연합 IT 벤처 창업 동아리" />
-        <meta property="twitter:card" content="website" />
-        <meta property="twitter:site" content="https://sopt.org/" />
-        <meta
-          name="twitter:image"
-          content="https://s3.ap-northeast-2.amazonaws.com/sopt.org/admin/origin/img_sopt_homepage.png"
-        />
-        <meta property="twitter:image:alt" content="SOPT 공식 홈페이지 이미지" />
-      </Head>
+      <HTMLHead />
       <GoogleTagManagerScript />
       <Global styles={global} />
       <ThemeProvider theme={theme}>

--- a/src/views/ProjectDetailPage/ProjectDetailPage.tsx
+++ b/src/views/ProjectDetailPage/ProjectDetailPage.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/router';
 import { useState } from 'react';
 import { useQuery } from 'react-query';
 import { ReactComponent as IToggle } from '@src/assets/images/toggle.svg';
+import HTMLHead from '@src/components/common/HTMLHead';
 import PageLayout from '@src/components/common/PageLayout';
 import { api } from '@src/lib/api';
 import { ProjectLinkType } from '@src/lib/types/project';
@@ -49,6 +50,7 @@ function ProjectDetailPage() {
 
   return (
     <PageLayout showScrollTopButton>
+      <HTMLHead title={name} imageURL={projectImage} projectID={id} />
       <S.Root>
         <S.Container>
           <S.ProjectHeader>

--- a/src/views/ProjectDetailPage/ProjectDetailPage.tsx
+++ b/src/views/ProjectDetailPage/ProjectDetailPage.tsx
@@ -50,7 +50,7 @@ function ProjectDetailPage() {
 
   return (
     <PageLayout showScrollTopButton>
-      <HTMLHead title={name} imageURL={projectImage} projectID={id} />
+      <HTMLHead projectTitle={name} projectImageURL={projectImage} projectID={id} />
       <S.Root>
         <S.Container>
           <S.ProjectHeader>


### PR DESCRIPTION
## Summary
head 태그들을 하나의 컴포넌트로 분리했습니다! 그리고 프로젝트 url 을 공유할때 og 가 다르게 보이도록 하였어요!

## Screenshot
<img width="813" alt="image" src="https://github.com/sopt-makers/sopt.org-frontend/assets/62867581/6a633e59-73c7-4051-9c07-b61c43cd412b">
(로컬에서 테스트를 할때, image가 적용이 안된채로 나오는데,,, 이거는 배포하고 다시 확인해볼게요!)

## Comment
공통 컴포넌트로 분리해보았는데, 폴더 구조가 어떤지 피드백 부탁드려요~