### PR TITLE
[SP1] 리쿠르팅 알림 신청 입력란에 이메일 pattern 추가

### DIFF
--- a/src/views/RecruitPage/components/NotificationSection/index.tsx
+++ b/src/views/RecruitPage/components/NotificationSection/index.tsx
@@ -1,8 +1,8 @@
 import { track } from '@amplitude/analytics-browser';
 import styled from '@emotion/styled';
+import { useRef, useState } from 'react';
 import { BASE_URL, DEFAULT_TIMEOUT } from '@src/lib/constants/client';
 import axios from 'axios';
-import { useRef, useState } from 'react';
 
 const client = axios.create({
   baseURL: BASE_URL,
@@ -53,6 +53,7 @@ const NotificationSection = () => {
         <Input
           type="email"
           placeholder="메일을 입력해주세요"
+          pattern="[a-zA-Z0-9]+[@][a-zA-Z0-9]+[.]+[a-zA-Z]+[.]*[a-zA-Z]*"
           ref={emailInputRef}
           onClick={() => track('click_recruit_notification_input')}
         />


### PR DESCRIPTION
## Summary
![image](https://github.com/sopt-makers/sopt.org-frontend/assets/62867581/188b789a-08ed-4bbf-aea2-544aefbed4de)
기존에 사진과 같이 이메일 형식에 맞지 않은 값이 저장이 되어서 pattern 을 추가해 이를 해결했습니다!

## Screenshot
<img width="1017" alt="스크린샷 2023-10-13 오후 10 19 31" src="https://github.com/sopt-makers/sopt.org-frontend/assets/62867581/9db6a529-4583-4d73-98c6-ca137ae8b655">
다음과 같이 input 자체에 경고 메시지가 뜹니다!

## Comment
