### PR TITLE
[SP2] 네비게이션 클릭 범위 수정

### DIFF
--- a/src/components/Header/Desktop/DesktopHeader.tsx
+++ b/src/components/Header/Desktop/DesktopHeader.tsx
@@ -1,7 +1,6 @@
 import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
 import Link from 'next/link';
-import { css } from '@emotion/react';
 import { LOGO_IMAGE_URL } from '@src/assets/mainLogo/base64_logo';
 import useHeader from '@src/hooks/useHeader';
 import { GrowDown } from '@src/lib/styles/animation';
@@ -42,8 +41,8 @@ function MenuTap({ menuTap, handleIsSelected }: MenuTapProps) {
       );
     case MenuTapType.Router:
       return (
-        <MenuTitle isSelected={handleIsSelected(menuTap.href)}>
-          <Link href={menuTap.href}>{menuTap.title}</Link>
+        <MenuTitle href={menuTap.href} isSelected={handleIsSelected(menuTap.href)}>
+          {menuTap.title}
         </MenuTitle>
       );
   }
@@ -115,7 +114,7 @@ export const MenuTitleAnchor = styled(Link)`
   }
 `;
 
-export const MenuTitle = styled.div<MenuTitleProps>`
+export const MenuTitle = styled(Link)<MenuTitleProps>`
   font-size: 18px;
   height: 100%;
   line-height: 36px;
@@ -125,23 +124,16 @@ export const MenuTitle = styled.div<MenuTitleProps>`
   cursor: pointer;
   position: relative;
 
-  &:not(:last-child) {
-    padding-right: 40px;
-  }
+  padding: 0 20px 0 20px;
 
   &:hover {
     &::after {
       content: '';
       position: absolute;
       top: 3.5rem; /* this is bad practice */
-      left: -20px;
+      left: 0;
       width: 100%;
       border-bottom: 2px solid ${colors.white};
-    }
-    &:last-child {
-      &::after {
-        width: calc(100% + 40px);
-      }
     }
   }
 `;

--- a/src/components/common/Select/style.ts
+++ b/src/components/common/Select/style.ts
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
+import { colors } from '@sopt-makers/colors';
 import arrowDown from '@src/assets/icons/arrow_down.svg';
-import { colors } from '@src/lib/styles/colors';
 
 const SelectWrapper = styled.div`
   position: relative;

--- a/src/views/ProjectPage/styles.ts
+++ b/src/views/ProjectPage/styles.ts
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { colors } from '@src/lib/styles/colors';
+import { colors } from '@sopt-makers/colors';
 
 export const SectionTitle = styled.div`
   color: ${colors.gray10};


### PR DESCRIPTION
## Summary
- close #238 

## Comment
- 해당 이슈 [논의 스레드](https://sopt-makers.slack.com/archives/C042T8GEA0Y/p1698133445535069)입니다.
- 네비게이션 글씨 사이 간격이 마진(이미지 마우스 올린 부분)인데 해당 부분을 클릭해도 반응이 없는 상태입니다. 아래 흰 선으로 인해 클릭이 가능할 것처럼 보이지만 클릭이 되지 않고 있어 UX상 좋지 않다고 생각하였습니다.
  ![image](https://github.com/sopt-makers/sopt.org-frontend/assets/63948884/de51030c-1dae-4e18-83f5-837da5388f72)
- 기획과 논의 후 클릭 범위를 흰 선과 맞추기로 하였습니다.