### PR TITLE
[SP2] 프로젝트 탭 캐러셀 블러 스타일 수정

### DIFF
--- a/src/components/common/Carousel/index.tsx
+++ b/src/components/common/Carousel/index.tsx
@@ -79,6 +79,7 @@ export default function Carousel({
           translateX={translateX}
           itemWidth={itemWidth}
           itemCount={children.length}
+          gapWidth={gapWidth}
           onTouchStart={handleTouchStart}
           onTouchEnd={handleTouchEnd}
         >

--- a/src/components/common/Carousel/index.tsx
+++ b/src/components/common/Carousel/index.tsx
@@ -4,6 +4,7 @@ import { S } from './style';
 
 interface CarouselProps {
   itemWidth: number;
+  gapWidth: number;
   stride?: number;
   leftArrowType?: CarouselArrowType;
   rightArrowType?: CarouselArrowType;
@@ -15,6 +16,7 @@ const SWIPE_THRESHOLD = 50;
 
 export default function Carousel({
   itemWidth,
+  gapWidth,
   stride = 1,
   leftArrowType = CarouselArrowType.External,
   rightArrowType = CarouselArrowType.External,
@@ -24,17 +26,26 @@ export default function Carousel({
   const [currentIndex, setCurrentIndex] = useState(0);
   const [startX, setStartX] = useState(0);
   const wrapperRef = useRef<HTMLDivElement>(null);
+  const [isSliding, setIsSliding] = useState(false);
+  const lastIndex = currentIndex === children.length - 1;
 
   useEffect(() => {
     setCurrentIndex(0);
   }, [stride, itemWidth]);
 
+  const handleSlideStatus = () => {
+    setIsSliding(true);
+    setTimeout(() => setIsSliding(false), 300);
+  };
+
   const handlePrev = () => {
     setCurrentIndex(Math.max(0, currentIndex - stride));
+    handleSlideStatus();
   };
 
   const handleNext = () => {
     setCurrentIndex(Math.min(children.length - 1, currentIndex + stride));
+    handleSlideStatus();
   };
 
   const handleTouchStart = (e: React.TouchEvent<HTMLDivElement>) => {
@@ -52,10 +63,10 @@ export default function Carousel({
     }
   };
 
-  const translateX = -currentIndex * itemWidth;
+  const translateX = -currentIndex * (itemWidth + gapWidth);
 
   return (
-    <S.Wrapper ref={wrapperRef}>
+    <S.Wrapper ref={wrapperRef} isSliding={isSliding} lastIndex={lastIndex}>
       {overflowType === CarouselOverflowType.Blur && (
         <>
           <S.LeftBlur />

--- a/src/components/common/Carousel/style.ts
+++ b/src/components/common/Carousel/style.ts
@@ -77,17 +77,14 @@ const CarouselWrapper = styled.div<{
   translateX: number;
   itemWidth: number;
   itemCount: number;
+  gapWidth: number;
 }>`
   width: ${({ itemWidth, itemCount }) => itemWidth * itemCount}px;
   display: grid;
   grid-template-columns: ${({ itemWidth, itemCount }) => `repeat(${itemCount}, ${itemWidth}px)`};
   transition: transform 0.5s ease-in-out;
   transform: ${({ translateX }) => `translateX(${translateX}px)`};
-  gap: 24px;
-
-  @media (max-width: 899px) {
-    gap: 14px;
-  }
+  gap: ${({ gapWidth }) => `${gapWidth}px`};
 `;
 
 const CarouselViewport = styled.div`

--- a/src/components/common/Carousel/style.ts
+++ b/src/components/common/Carousel/style.ts
@@ -1,13 +1,50 @@
 import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
+import { css } from '@emotion/react';
 import arrowLeft from '@src/assets/icons/arrow_left_28x28.svg';
 import arrowRight from '@src/assets/icons/arrow_right_28x28.svg';
 import { HideScrollbar } from '@src/lib/styles/scrollbar';
 import { CarouselArrowType } from '@src/lib/types/universal';
 
-const Wrapper = styled(HideScrollbar)`
+const Wrapper = styled(HideScrollbar)<{ isSliding: boolean; lastIndex: boolean }>`
   width: 100%;
   position: relative;
+
+  ::before,
+  ::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    z-index: 5;
+
+    width: 70px;
+    height: 164px;
+  }
+
+  ::before {
+    left: 0;
+    background: linear-gradient(270deg, transparent 0%, ${colors.gray950} 100%);
+
+    opacity: ${({ isSliding }) => (isSliding ? '1' : '0')};
+    transition: opacity 0.3s ease-out;
+  }
+
+  ::after {
+    right: 0;
+    background: linear-gradient(270deg, ${colors.gray950} 0%, transparent 100%);
+
+    opacity: 0;
+    ${({ isSliding }) =>
+      isSliding &&
+      css`
+        opacity: 1;
+        transition: opacity 0.3s ease-out;
+      `};
+
+    @media (max-width: 1279px) {
+      opacity: ${({ lastIndex }) => (lastIndex ? 0 : 1)};
+    }
+  }
 `;
 
 const Arrow = styled.div<{ type: CarouselArrowType }>`
@@ -46,6 +83,11 @@ const CarouselWrapper = styled.div<{
   grid-template-columns: ${({ itemWidth, itemCount }) => `repeat(${itemCount}, ${itemWidth}px)`};
   transition: transform 0.5s ease-in-out;
   transform: ${({ translateX }) => `translateX(${translateX}px)`};
+  gap: 24px;
+
+  @media (max-width: 899px) {
+    gap: 14px;
+  }
 `;
 
 const CarouselViewport = styled.div`
@@ -58,12 +100,7 @@ const Blur = styled.div`
   height: 100%;
   width: calc(50vw - 50%);
   top: 0;
-  background: linear-gradient(
-    to right,
-    transparent 10px,
-    ${colors.background} 50px,
-    ${colors.background}
-  );
+  background: ${colors.background};
 `;
 
 const LeftBlur = styled(Blur)`

--- a/src/components/common/Carousel/style.ts
+++ b/src/components/common/Carousel/style.ts
@@ -30,7 +30,7 @@ const Wrapper = styled(HideScrollbar)<{ isSliding: boolean; lastIndex: boolean }
   }
 
   ::after {
-    right: 0;
+    right: -1px;
     background: linear-gradient(270deg, ${colors.gray950} 0%, transparent 100%);
 
     opacity: 0;

--- a/src/views/ProjectPage/components/RecentProjectList/Carousel/index.tsx
+++ b/src/views/ProjectPage/components/RecentProjectList/Carousel/index.tsx
@@ -14,7 +14,8 @@ export default function RecentProjectListCarousel({ children }: { children: JSX.
   return (
     <Carousel
       stride={isDesktopSize ? 2 : 1}
-      itemWidth={isMobileSize ? 345 : 544}
+      itemWidth={isMobileSize ? 320 : 544}
+      gapWidth={isMobileSize ? 14 : 24}
       leftArrowType={arrowType}
       rightArrowType={arrowType}
       overflowType={overflowType}

--- a/src/views/ProjectPage/components/RecentProjectList/Item/style.ts
+++ b/src/views/ProjectPage/components/RecentProjectList/Item/style.ts
@@ -6,7 +6,7 @@ import icArrowStickRight from '@src/assets/icons/ic_arrow_stick_right.svg';
 import { textSingularLineEllipsis } from '@src/lib/styles/textEllipsis';
 
 const GridWrapper = styled.div`
-  width: 524px;
+  width: 544px;
   display: grid;
   grid-template-areas: 'img detail' 'img footer';
   grid-template-columns: 116px auto;
@@ -14,10 +14,10 @@ const GridWrapper = styled.div`
   background-color: ${colors.gray900};
   border-radius: 12px;
   padding: 24px;
-  margin-right: 20px;
+
   /* 모바일 뷰 */
   @media (max-width: 899px) {
-    width: 325px;
+    width: 320px;
     grid-template-areas:
       'img detail'
       'footer footer';


### PR DESCRIPTION
## Summary
- close #265 

## Screenshot
**[ 디자인 QA ]**

![image](https://github.com/sopt-makers/sopt.org-frontend/assets/63948884/9b16a5af-f8dd-474f-b9cd-d68c3cd99978)


피그마를 확인했을 때 캐러셀 옆이 **블러 처리가 될 때**가 _슬라이드 아이템이 잘려서 보이는 경우_ 와 _슬라이드를 넘길 때_ 라고 생각됩니다.
|슬라이드 아이템이 잘려서 보이는 경우|슬라이드를 넘길 때 |
|--|--|
|![image](https://github.com/sopt-makers/sopt.org-frontend/assets/63948884/ee58ebee-fa09-470c-a254-e35420636a2a)|![image](https://github.com/sopt-makers/sopt.org-frontend/assets/63948884/1efaf3fd-a4ec-424c-b3b3-7767c65c849f)|

**[ 기존 ]** 

https://github.com/sopt-makers/sopt.org-frontend/assets/63948884/7dbfa3a3-f94c-409e-bc3a-062859b49927

**[ 수정 후 ]**

https://github.com/sopt-makers/sopt.org-frontend/assets/63948884/d679e2a1-135d-42f7-8b30-bd91adf2ef5a

## Comment

- 아래 QA의 경우에는 제 컴퓨터에서는 나타나지 않던 현상이어서 확인이 어렵습니다.. dev 페이지 배포 후 확인을 부탁드려야 할 것 같습니다.

![image](https://github.com/sopt-makers/sopt.org-frontend/assets/63948884/43b4110e-3a93-4d06-9cc4-de43d4ac6767)
