### PR TITLE
[SP2] CI 에러 고치기, 리크루팅 탭 활동후기 복원

### DIFF
--- a/src/views/BlogPage/hooks/useInfiniteScroll.ts
+++ b/src/views/BlogPage/hooks/useInfiniteScroll.ts
@@ -1,6 +1,5 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { FetchNextPageOptions, InfiniteQueryObserverResult } from 'react-query';
-import useBooleanState from '@src/hooks/useBooleanState';
 import useIntersectionObserver from '@src/hooks/useIntersectionObserver';
 import { BlogResponse } from '@src/lib/types/blog';
 
@@ -8,23 +7,23 @@ export default function useInfiniteScroll(fetchNextPage: {
   (options?: FetchNextPageOptions): Promise<InfiniteQueryObserverResult<BlogResponse>>;
   (): void;
 }) {
-  const [hasObserved, setHasObserved, setHasUnObserved] = useBooleanState(false);
+  const [hasObserved, setHasObserved] = useState(false);
 
   const ref = useIntersectionObserver(
     async (entry, observer) => {
       if (!hasObserved && entry.isIntersecting) {
         fetchNextPage();
-        setHasObserved();
+        setHasObserved(true);
       }
 
       observer.unobserve(entry.target);
-      setHasUnObserved();
+      setHasObserved(false);
     },
     { rootMargin: '80px' },
   );
 
   useEffect(() => {
-    setHasUnObserved();
+    setHasObserved(false);
   }, []);
 
   return { ref };

--- a/src/views/RecruitPage/components/ActivityReview/index.tsx
+++ b/src/views/RecruitPage/components/ActivityReview/index.tsx
@@ -44,7 +44,7 @@ export default function ActivityReview() {
           <ArrowLeft stroke={isLeftScrollable ? 'white' : 'grey'} />
         </ArrowWrapper>
         <Content ref={scrollableRef}>
-          {/* {reviews.data.map((review) => (
+          {reviews.data.map((review) => (
             <Link
               key={review.id}
               href={review.url}
@@ -66,7 +66,7 @@ export default function ActivityReview() {
                 </DescWrapper>
               </CardWrapper>
             </Link>
-          ))} */}
+          ))}
         </Content>
         <ArrowWrapper onClick={() => onClickRightButton(scrollableRef.current)}>
           <ArrowRight stroke={isRightScrollable ? 'white' : 'grey'} />


### PR DESCRIPTION
- close #267 

## Summary
CI 워닝이 뜨던 것을 고쳤습니다!

<img width="664" alt="image" src="https://github.com/sopt-makers/sopt.org-frontend/assets/48249505/9cb35b9e-0619-4bc0-8d6e-fd5cca484df3">

## Screenshot
<img width="945" alt="image" src="https://github.com/sopt-makers/sopt.org-frontend/assets/48249505/8a8c6560-7940-48e7-932d-e147b492af94">
리크루팅 탭의 활동 후기 부분이 주석으로 봉인되어 있더라고요 ..!! 그것으로부터 풀어주었습니다.
혹시 이것의 히스토리를 아시는 분이 있으신가요?
봉인을 해제해도 되는게 맞는지 알아봐야 할 것 같아요

## Comment
- useBooleanState 훅을 사용하면, 그것이 리턴하는 setTrue, setFalse 함수를 useEffect에서 호출했을 때 의존성 배열에 넣어주어야 하네요 .. 그런데 의미상 필요하지 않은 것 같아서 useState를 쓰는 코드로 변경했는데, 더 좋은 해결방법이 있다면 말씀해 주시면 감사하겠습니다!
