### PR TITLE
[SP2] 모바일에서도 프로젝트 탭 캐러셀의 화살표가 보여 깨지는 현상 수정

### DIFF
--- a/src/components/common/Carousel/style.ts
+++ b/src/components/common/Carousel/style.ts
@@ -48,7 +48,7 @@ const Wrapper = styled(HideScrollbar)<{ isSliding: boolean; lastIndex: boolean }
 `;
 
 const Arrow = styled.div<{ type: CarouselArrowType }>`
-  ${({ type }) => type === CarouselArrowType.None && 'display: hidden;'}
+  ${({ type }) => type === CarouselArrowType.None && 'display: none;'}
   position: absolute;
   width: 40px;
   height: 40px;


### PR DESCRIPTION
## Summary
[SP2] 모바일에서도 프로젝트 탭 캐러셀의 화살표가 보여 깨지는 현상을 수정합니다.

## Screenshot
<img width="544" alt="스크린샷 2023-11-09 오후 9 13 12" src="https://github.com/sopt-makers/sopt.org-frontend/assets/48249505/bc250fa0-5bc1-4fe1-a7d5-04426a07839e">

## Comment
display:hidden 같은건 없고 .. none 입니당...