### PR TITLE
[SP2] 프로젝트 탭 디자인 일부 수정

### DIFF
--- a/src/components/common/Carousel/index.tsx
+++ b/src/components/common/Carousel/index.tsx
@@ -9,6 +9,7 @@ interface CarouselProps {
   leftArrowType?: CarouselArrowType;
   rightArrowType?: CarouselArrowType;
   overflowType?: CarouselOverflowType;
+  isDesktop?: boolean;
   children: JSX.Element[];
 }
 
@@ -18,9 +19,7 @@ export default function Carousel({
   itemWidth,
   gapWidth,
   stride = 1,
-  leftArrowType = CarouselArrowType.External,
-  rightArrowType = CarouselArrowType.External,
-  overflowType = CarouselOverflowType.Blur,
+  isDesktop,
   children,
 }: CarouselProps) {
   const [currentIndex, setCurrentIndex] = useState(0);
@@ -67,13 +66,11 @@ export default function Carousel({
 
   return (
     <S.Wrapper ref={wrapperRef} isSliding={isSliding} lastIndex={lastIndex}>
-      {overflowType === CarouselOverflowType.Blur && (
-        <>
-          <S.LeftBlur />
-          <S.RightBlur />
-        </>
-      )}
-      {currentIndex !== 0 && <S.LeftArrow type={leftArrowType} onClick={handlePrev} />}
+      <>
+        <S.LeftBlur />
+        <S.RightBlur />
+      </>
+      {currentIndex !== 0 && <S.LeftArrow onClick={handlePrev} />}
       <S.CarouselViewport>
         <S.CarouselWrapper
           translateX={translateX}
@@ -86,18 +83,18 @@ export default function Carousel({
           {children}
         </S.CarouselWrapper>
       </S.CarouselViewport>
-      {currentIndex !== children.length - stride && (
-        <S.RightArrow type={rightArrowType} onClick={handleNext} />
+      {currentIndex !== children.length - stride && <S.RightArrow onClick={handleNext} />}
+      {isDesktop && (
+        <S.DotWrapper>
+          {Array.from({ length: Math.ceil(children.length / stride) }).map((dot, index) => (
+            <S.Dot
+              key={index}
+              onClick={() => setCurrentIndex(index * stride)}
+              selected={index === Math.floor(currentIndex / stride)}
+            />
+          ))}
+        </S.DotWrapper>
       )}
-      <S.DotWrapper>
-        {Array.from({ length: Math.ceil(children.length / stride) }).map((dot, index) => (
-          <S.Dot
-            key={index}
-            onClick={() => setCurrentIndex(index * stride)}
-            selected={index === Math.floor(currentIndex / stride)}
-          />
-        ))}
-      </S.DotWrapper>
     </S.Wrapper>
   );
 }

--- a/src/components/common/Carousel/style.ts
+++ b/src/components/common/Carousel/style.ts
@@ -4,7 +4,6 @@ import { css } from '@emotion/react';
 import arrowLeft from '@src/assets/icons/arrow_left_28x28.svg';
 import arrowRight from '@src/assets/icons/arrow_right_28x28.svg';
 import { HideScrollbar } from '@src/lib/styles/scrollbar';
-import { CarouselArrowType } from '@src/lib/types/universal';
 
 const Wrapper = styled(HideScrollbar)<{ isSliding: boolean; lastIndex: boolean }>`
   width: 100%;
@@ -51,8 +50,7 @@ const Wrapper = styled(HideScrollbar)<{ isSliding: boolean; lastIndex: boolean }
   }
 `;
 
-const Arrow = styled.div<{ type: CarouselArrowType }>`
-  ${({ type }) => type === CarouselArrowType.None && 'display: none;'}
+const Arrow = styled.div`
   position: absolute;
   width: 40px;
   height: 40px;
@@ -71,12 +69,12 @@ const Arrow = styled.div<{ type: CarouselArrowType }>`
   }
 `;
 
-const LeftArrow = styled(Arrow)<{ type: CarouselArrowType }>`
+const LeftArrow = styled(Arrow)`
   left: -50px;
   background-image: url(${arrowLeft});
 `;
 
-const RightArrow = styled(Arrow)<{ type: CarouselArrowType }>`
+const RightArrow = styled(Arrow)`
   right: -50px;
   background-image: url(${arrowRight});
 `;

--- a/src/components/common/Carousel/style.ts
+++ b/src/components/common/Carousel/style.ts
@@ -19,6 +19,10 @@ const Wrapper = styled(HideScrollbar)<{ isSliding: boolean; lastIndex: boolean }
 
     width: 70px;
     height: 164px;
+
+    @media (max-width: 899px) {
+      display: none;
+    }
   }
 
   ::before {
@@ -61,6 +65,10 @@ const Arrow = styled.div<{ type: CarouselArrowType }>`
   cursor: pointer;
   background-repeat: no-repeat;
   background-position: center;
+
+  @media (max-width: 899px) {
+    display: none;
+  }
 `;
 
 const LeftArrow = styled(Arrow)<{ type: CarouselArrowType }>`
@@ -98,6 +106,10 @@ const Blur = styled.div`
   width: calc(50vw - 50%);
   top: 0;
   background: ${colors.background};
+
+  @media (max-width: 899px) {
+    display: none;
+  }
 `;
 
 const LeftBlur = styled(Blur)`

--- a/src/components/common/Select/index.tsx
+++ b/src/components/common/Select/index.tsx
@@ -57,9 +57,9 @@ export default function Select<T extends LabelKeyType>({
               isSelected={selectedValue === option}
               onClick={() => handleSelect(option)}
             >
-              <S.SelectItmeContent isWide={currentSelectedValue.length >= 5}>
+              <S.SelectItemContent isWide={currentSelectedValue.length >= 5}>
                 {labels[option]}
-              </S.SelectItmeContent>
+              </S.SelectItemContent>
             </S.SelectItem>
           ))}
         </S.SelectItemWrapper>

--- a/src/components/common/Select/index.tsx
+++ b/src/components/common/Select/index.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useRef, useState } from 'react';
 import useOutsideClickListener from '@src/hooks/useOutsideClickListener';
-import { LabelKeyType } from '@src/lib/types/universal';
-import { S } from './style';
+import { pageBreakPoint } from '@src/lib/constants/project';
+import { LabelKeyType, PageType } from '@src/lib/types/universal';
+import * as S from './style';
 
 interface SelectProps<T extends LabelKeyType> {
   options: T[];
@@ -10,6 +11,7 @@ interface SelectProps<T extends LabelKeyType> {
   selectedValue: T;
   setSelectedValue: (newValue: T) => void;
   labels: Record<T, string>;
+  page: PageType;
 }
 
 export default function Select<T extends LabelKeyType>({
@@ -19,6 +21,7 @@ export default function Select<T extends LabelKeyType>({
   baseValue,
   baseLabel,
   labels,
+  page,
 }: SelectProps<T>) {
   const [isOpen, setIsOpen] = useState(false);
 
@@ -35,35 +38,48 @@ export default function Select<T extends LabelKeyType>({
   const currentSelectedValue = labels[selectedValue];
   useOutsideClickListener([selectItemWrapperRef, selectTriggerRef], closeSelectItem);
 
+  const breakPoint = pageBreakPoint[page];
+
   return (
-    <div>
+    <>
       <S.SelectTrigger
         ref={selectTriggerRef}
         onClick={toggleSelect}
         isSelectionExist={selectedValue !== baseValue}
         isOpened={isOpen}
         isWide={currentSelectedValue.length >= 5}
+        breakPoint={breakPoint}
       >
-        <S.SelectTriggerContent isSelectionExist={selectedValue !== baseValue}>
+        <S.SelectTriggerContent
+          isSelectionExist={selectedValue !== baseValue}
+          breakPoint={breakPoint}
+        >
           {selectedValue === baseValue ? baseLabel : currentSelectedValue}
         </S.SelectTriggerContent>
         <S.Arrow isOpened={isOpen} />
       </S.SelectTrigger>
       {isOpen && (
-        <S.SelectItemWrapper ref={selectItemWrapperRef} isWide={currentSelectedValue.length >= 5}>
+        <S.SelectItemWrapper
+          ref={selectItemWrapperRef}
+          isWide={currentSelectedValue.length >= 5}
+          breakPoint={breakPoint}
+        >
           {options.map((option, index) => (
             <S.SelectItem
               key={index}
               isSelected={selectedValue === option}
               onClick={() => handleSelect(option)}
             >
-              <S.SelectItemContent isWide={currentSelectedValue.length >= 5}>
+              <S.SelectItemContent
+                isWide={currentSelectedValue.length >= 5}
+                breakPoint={breakPoint}
+              >
                 {labels[option]}
               </S.SelectItemContent>
             </S.SelectItem>
           ))}
         </S.SelectItemWrapper>
       )}
-    </div>
+    </>
   );
 }

--- a/src/components/common/Select/index.tsx
+++ b/src/components/common/Select/index.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useRef, useState } from 'react';
 import useOutsideClickListener from '@src/hooks/useOutsideClickListener';
-import { pageBreakPoint } from '@src/lib/constants/project';
-import { LabelKeyType, PageType } from '@src/lib/types/universal';
+import { LabelKeyType } from '@src/lib/types/universal';
 import * as S from './style';
 
 interface SelectProps<T extends LabelKeyType> {
@@ -11,7 +10,7 @@ interface SelectProps<T extends LabelKeyType> {
   selectedValue: T;
   setSelectedValue: (newValue: T) => void;
   labels: Record<T, string>;
-  page: PageType;
+  breakPoint: string;
 }
 
 export default function Select<T extends LabelKeyType>({
@@ -21,7 +20,7 @@ export default function Select<T extends LabelKeyType>({
   baseValue,
   baseLabel,
   labels,
-  page,
+  breakPoint,
 }: SelectProps<T>) {
   const [isOpen, setIsOpen] = useState(false);
 
@@ -37,8 +36,6 @@ export default function Select<T extends LabelKeyType>({
   const selectTriggerRef = useRef<HTMLButtonElement>(null);
   const currentSelectedValue = labels[selectedValue];
   useOutsideClickListener([selectItemWrapperRef, selectTriggerRef], closeSelectItem);
-
-  const breakPoint = pageBreakPoint[page];
 
   return (
     <div>

--- a/src/components/common/Select/index.tsx
+++ b/src/components/common/Select/index.tsx
@@ -41,7 +41,7 @@ export default function Select<T extends LabelKeyType>({
   const breakPoint = pageBreakPoint[page];
 
   return (
-    <>
+    <div>
       <S.SelectTrigger
         ref={selectTriggerRef}
         onClick={toggleSelect}
@@ -80,6 +80,6 @@ export default function Select<T extends LabelKeyType>({
           ))}
         </S.SelectItemWrapper>
       )}
-    </>
+    </div>
   );
 }

--- a/src/components/common/Select/style.ts
+++ b/src/components/common/Select/style.ts
@@ -67,7 +67,7 @@ const SelectTriggerContent = styled.p<{
   font-weight: 500;
 `;
 
-const SelectItmeContent = styled.p<{
+const SelectItemContent = styled.p<{
   isWide: boolean;
 }>`
   margin-right: ${({ isWide }) => isWide && '42px'};
@@ -109,6 +109,6 @@ export const S = {
   SelectTrigger,
   SelectItem,
   SelectTriggerContent,
-  SelectItmeContent,
+  SelectItemContent,
   SelectItemWrapper,
 };

--- a/src/components/common/Select/style.ts
+++ b/src/components/common/Select/style.ts
@@ -25,7 +25,7 @@ export const SelectTrigger = styled.button<{
   border: 1px solid;
   border-color: ${({ isSelectionExist }) => (isSelectionExist ? colors.gray400 : colors.gray700)};
 
-  @media (max-width: ${({ breakPoint }) => `${breakPoint}px`}) {
+  @media (max-width: ${({ breakPoint }) => breakPoint}) {
     min-width: 76px;
     padding: 8px 12px;
     border-radius: 99px;
@@ -63,7 +63,7 @@ export const SelectTriggerContent = styled.p<{ isSelectionExist: boolean; breakP
   font-weight: 500;
   white-space: nowrap;
 
-  @media (max-width: ${({ breakPoint }) => `${breakPoint}px`}) {
+  @media (max-width: ${({ breakPoint }) => breakPoint}) {
     font-size: 13px;
   }
 `;
@@ -71,7 +71,7 @@ export const SelectTriggerContent = styled.p<{ isSelectionExist: boolean; breakP
 export const SelectItemContent = styled.p<{ isWide: boolean; breakPoint: string }>`
   margin-right: ${({ isWide }) => isWide && '42px'};
 
-  @media (max-width: ${({ breakPoint }) => `${breakPoint}px`}) {
+  @media (max-width: ${({ breakPoint }) => breakPoint}) {
     margin-right: ${({ isWide }) => isWide && '22px'};
     font-size: 13px;
   }
@@ -103,7 +103,7 @@ export const SelectItemWrapper = styled.div<{ isWide: boolean; breakPoint: strin
     }
   }
 
-  @media (max-width: ${({ breakPoint }) => `${breakPoint}px`}) {
+  @media (max-width: ${({ breakPoint }) => breakPoint}) {
     min-width: 76px;
   }
 `;

--- a/src/components/common/Select/style.ts
+++ b/src/components/common/Select/style.ts
@@ -2,14 +2,11 @@ import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
 import chevronDown from '@src/assets/icons/chevronDown.svg';
 
-const SelectWrapper = styled.div`
-  position: relative;
-`;
-
-const SelectTrigger = styled.button<{
+export const SelectTrigger = styled.button<{
   isSelectionExist: boolean;
   isOpened: boolean;
   isWide: boolean;
+  breakPoint: string;
 }>`
   display: flex;
   flex-direction: row;
@@ -28,7 +25,8 @@ const SelectTrigger = styled.button<{
   border: 1px solid;
   border-color: ${({ isSelectionExist }) => (isSelectionExist ? colors.gray400 : colors.gray700)};
 
-  @media (max-width: 899px) {
+  @media (max-width: ${({ breakPoint }) => `${breakPoint}px`}) {
+    min-width: 76px;
     padding: 8px 12px;
     border-radius: 99px;
     font-size: 13px;
@@ -37,7 +35,7 @@ const SelectTrigger = styled.button<{
   }
 `;
 
-const Arrow = styled.div<{
+export const Arrow = styled.div<{
   isOpened: boolean;
 }>`
   background-repeat: no-repeat;
@@ -49,7 +47,7 @@ const Arrow = styled.div<{
   transform: ${({ isOpened }) => (isOpened ? 'rotate(180deg)' : 'none')};
 `;
 
-const SelectItem = styled.div<{ isSelected: boolean }>`
+export const SelectItem = styled.div<{ isSelected: boolean }>`
   background-color: ${({ isSelected }) => (isSelected ? colors.gray600 : 'transparent')};
   padding: 8px 5px;
   border-radius: 6px;
@@ -58,25 +56,28 @@ const SelectItem = styled.div<{ isSelected: boolean }>`
   color: ${colors.gray30};
 `;
 
-const SelectTriggerContent = styled.p<{
-  isSelectionExist: boolean;
-}>`
+export const SelectTriggerContent = styled.p<{ isSelectionExist: boolean; breakPoint: string }>`
   color: ${({ isSelectionExist }) => (isSelectionExist ? colors.white : colors.gray200)};
   margin-right: 8px;
   font-size: 16px;
   font-weight: 500;
-`;
+  white-space: nowrap;
 
-const SelectItemContent = styled.p<{
-  isWide: boolean;
-}>`
-  margin-right: ${({ isWide }) => isWide && '42px'};
-  @media (max-width: 899px) {
-    margin-right: ${({ isWide }) => isWide && '22px'};
+  @media (max-width: ${({ breakPoint }) => `${breakPoint}px`}) {
+    font-size: 13px;
   }
 `;
 
-const SelectItemWrapper = styled.div<{ isWide: boolean }>`
+export const SelectItemContent = styled.p<{ isWide: boolean; breakPoint: string }>`
+  margin-right: ${({ isWide }) => isWide && '42px'};
+
+  @media (max-width: ${({ breakPoint }) => `${breakPoint}px`}) {
+    margin-right: ${({ isWide }) => isWide && '22px'};
+    font-size: 13px;
+  }
+`;
+
+export const SelectItemWrapper = styled.div<{ isWide: boolean; breakPoint: string }>`
   display: flex;
   flex-direction: column;
 
@@ -101,14 +102,8 @@ const SelectItemWrapper = styled.div<{ isWide: boolean }>`
       }
     }
   }
-`;
 
-export const S = {
-  SelectWrapper,
-  Arrow,
-  SelectTrigger,
-  SelectItem,
-  SelectTriggerContent,
-  SelectItemContent,
-  SelectItemWrapper,
-};
+  @media (max-width: ${({ breakPoint }) => `${breakPoint}px`}) {
+    min-width: 76px;
+  }
+`;

--- a/src/lib/constants/project.ts
+++ b/src/lib/constants/project.ts
@@ -38,6 +38,6 @@ export const projectPlatformLabel: Record<ProjectPlatformType, string> = {
 };
 
 export const pageBreakPoint: Record<PageType, string> = {
-  [PageType.BLOG]: '767',
-  [PageType.PROJECT]: '899',
+  [PageType.BLOG]: '767px',
+  [PageType.PROJECT]: '899px',
 };

--- a/src/lib/constants/project.ts
+++ b/src/lib/constants/project.ts
@@ -1,4 +1,5 @@
 import { ProjectCategoryType, ProjectPlatformType } from '@src/lib/types/project';
+import { PageType } from '@src/lib/types/universal';
 
 export const activeProjectCategoryList: ProjectCategoryType[] = [
   ProjectCategoryType.ALL,
@@ -34,4 +35,9 @@ export const projectPlatformLabel: Record<ProjectPlatformType, string> = {
   [ProjectPlatformType.ALL]: '전체',
   [ProjectPlatformType.APP]: '앱',
   [ProjectPlatformType.WEB]: '웹',
+};
+
+export const pageBreakPoint: Record<PageType, string> = {
+  [PageType.BLOG]: '767',
+  [PageType.PROJECT]: '899',
 };

--- a/src/lib/types/universal.ts
+++ b/src/lib/types/universal.ts
@@ -48,3 +48,8 @@ export enum CarouselOverflowType {
   Blur = 'blur',
   Visible = 'visible',
 }
+
+export enum PageType {
+  BLOG = 'BLOG',
+  PROJECT = 'PROJECT',
+}

--- a/src/views/BlogPage/components/BlogTab/index.tsx
+++ b/src/views/BlogPage/components/BlogTab/index.tsx
@@ -7,6 +7,7 @@ import {
   partCategoryLabel,
 } from '@src/lib/constants/tabs';
 import { PartCategoryType } from '@src/lib/types/blog';
+import { PageType } from '@src/lib/types/universal';
 import * as S from './style';
 import { BlogTabMap, BlogTabType } from './types';
 import { selectedType } from './types';
@@ -64,6 +65,7 @@ export default function BlogTab({
             selectedValue={selectedMajorCategory}
             setSelectedValue={setMajorCategory}
             baseValue={activeGenerationCategoryList[0]}
+            page={PageType.BLOG}
           />
           <Select
             options={activePartCategoryList}
@@ -72,6 +74,7 @@ export default function BlogTab({
             selectedValue={selectedSubCategory}
             setSelectedValue={setSubCategory}
             baseValue={PartCategoryType.ALL}
+            page={PageType.BLOG}
           />
         </S.SlectContainer>
       </S.Container>

--- a/src/views/BlogPage/components/BlogTab/index.tsx
+++ b/src/views/BlogPage/components/BlogTab/index.tsx
@@ -1,5 +1,6 @@
 import { track } from '@amplitude/analytics-browser';
 import Select from '@src/components/common/Select';
+import { pageBreakPoint } from '@src/lib/constants/project';
 import {
   activeGenerationCategoryList,
   activePartCategoryList,
@@ -65,7 +66,7 @@ export default function BlogTab({
             selectedValue={selectedMajorCategory}
             setSelectedValue={setMajorCategory}
             baseValue={activeGenerationCategoryList[0]}
-            page={PageType.BLOG}
+            breakPoint={pageBreakPoint[PageType.BLOG]}
           />
           <Select
             options={activePartCategoryList}
@@ -74,7 +75,7 @@ export default function BlogTab({
             selectedValue={selectedSubCategory}
             setSelectedValue={setSubCategory}
             baseValue={PartCategoryType.ALL}
-            page={PageType.BLOG}
+            breakPoint={pageBreakPoint[PageType.BLOG]}
           />
         </S.SelectContainer>
       </S.Container>

--- a/src/views/BlogPage/components/BlogTab/index.tsx
+++ b/src/views/BlogPage/components/BlogTab/index.tsx
@@ -57,7 +57,7 @@ export default function BlogTab({
           })}
         </S.TabContainer>
         <S.TabDescription>{blogTabList[selectedTab]?.description}</S.TabDescription>
-        <S.SlectContainer>
+        <S.SelectContainer>
           <Select
             options={activeGenerationCategoryList}
             labels={generationCategoryLabel}
@@ -76,7 +76,7 @@ export default function BlogTab({
             baseValue={PartCategoryType.ALL}
             page={PageType.BLOG}
           />
-        </S.SlectContainer>
+        </S.SelectContainer>
       </S.Container>
     </S.Wrapper>
   );

--- a/src/views/BlogPage/components/BlogTab/style.ts
+++ b/src/views/BlogPage/components/BlogTab/style.ts
@@ -97,7 +97,7 @@ export const TabDescription = styled.h1`
   }
 `;
 
-export const SlectContainer = styled.section`
+export const SelectContainer = styled.section`
   display: flex;
   gap: 6px;
 `;

--- a/src/views/ProjectPage/ProjectPage.tsx
+++ b/src/views/ProjectPage/ProjectPage.tsx
@@ -10,6 +10,7 @@ import {
   projectPlatformLabel,
 } from '@src/lib/constants/project';
 import { ProjectCategoryType, ProjectPlatformType } from '@src/lib/types/project';
+import { PageType } from '@src/lib/types/universal';
 import { ProjectList } from '@src/views/ProjectPage/components/project/ProjectList';
 import ProjectListFallback from '@src/views/ProjectPage/components/project/ProjectListFallback';
 import RecentProjectList from './components/RecentProjectList';
@@ -49,6 +50,7 @@ function Projects() {
               selectedValue={selectedCategory}
               setSelectedValue={setCategory}
               baseValue={ProjectCategoryType.ALL}
+              page={PageType.PROJECT}
             />
             <Select
               options={activeProjectPlatformList}
@@ -57,6 +59,7 @@ function Projects() {
               selectedValue={selectedPlatform}
               setSelectedValue={setPlatform}
               baseValue={ProjectPlatformType.ALL}
+              page={PageType.PROJECT}
             />
           </S.FilterWrapper>
           <Suspense fallback={<ProjectListFallback />}>

--- a/src/views/ProjectPage/ProjectPage.tsx
+++ b/src/views/ProjectPage/ProjectPage.tsx
@@ -6,6 +6,7 @@ import useStorage from '@src/hooks/useStorage';
 import {
   activeProjectCategoryList,
   activeProjectPlatformList,
+  pageBreakPoint,
   projectCategoryLabel,
   projectPlatformLabel,
 } from '@src/lib/constants/project';
@@ -50,7 +51,7 @@ function Projects() {
               selectedValue={selectedCategory}
               setSelectedValue={setCategory}
               baseValue={ProjectCategoryType.ALL}
-              page={PageType.PROJECT}
+              breakPoint={pageBreakPoint[PageType.PROJECT]}
             />
             <Select
               options={activeProjectPlatformList}
@@ -59,7 +60,7 @@ function Projects() {
               selectedValue={selectedPlatform}
               setSelectedValue={setPlatform}
               baseValue={ProjectPlatformType.ALL}
-              page={PageType.PROJECT}
+              breakPoint={pageBreakPoint[PageType.PROJECT]}
             />
           </S.FilterWrapper>
           <Suspense fallback={<ProjectListFallback />}>

--- a/src/views/ProjectPage/components/RecentProjectList/Carousel/index.tsx
+++ b/src/views/ProjectPage/components/RecentProjectList/Carousel/index.tsx
@@ -1,24 +1,19 @@
 import Carousel from '@src/components/common/Carousel';
 import { useDeviceType, useIsDesktop, useIsMobile } from '@src/hooks/useDevice';
-import { CarouselArrowType, CarouselOverflowType } from '@src/lib/types/universal';
 
 export default function RecentProjectListCarousel({ children }: { children: JSX.Element[] }) {
   const isDesktopSize = useIsDesktop('1280px');
   const isMobileSize = useIsMobile('899px');
   const deviceType = useDeviceType();
 
-  const arrowType = deviceType === 'desktop' ? CarouselArrowType.External : CarouselArrowType.None;
-  const overflowType =
-    deviceType === 'desktop' ? CarouselOverflowType.Blur : CarouselOverflowType.Visible;
+  const isDesktop = deviceType === 'desktop';
 
   return (
     <Carousel
       stride={isDesktopSize ? 2 : 1}
       itemWidth={isMobileSize ? 320 : 544}
       gapWidth={isMobileSize ? 14 : 24}
-      leftArrowType={arrowType}
-      rightArrowType={arrowType}
-      overflowType={overflowType}
+      isDesktop={isDesktop}
     >
       {children}
     </Carousel>

--- a/src/views/ProjectPage/components/project/ProjectCard/style.ts
+++ b/src/views/ProjectPage/components/project/ProjectCard/style.ts
@@ -23,11 +23,12 @@ export const ProjectCard = styled(Link)`
   @media (max-width: 899px) {
     grid-template-areas:
       'thumbnail header'
-      'summary summary';
+      'summary summary'
+      'detail detail';
     grid-template-rows: none;
     grid-template-columns: auto 1fr;
     grid-gap: 12px;
-    
+
     width: 100%;
     height: auto;
     padding: 0 0 10px 0;

--- a/src/views/ProjectPage/components/project/ProjectCard/style.ts
+++ b/src/views/ProjectPage/components/project/ProjectCard/style.ts
@@ -62,6 +62,11 @@ export const ProjectText = styled.div`
 `;
 
 export const ProjectTitle = styled.div`
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 1;
+  overflow: hidden;
+
   color: ${colors.gray10};
 
   /* Heading/6_B */

--- a/src/views/ProjectPage/styles.ts
+++ b/src/views/ProjectPage/styles.ts
@@ -33,7 +33,11 @@ const Root = styled.div`
   /* 모바일 뷰 */
   @media (max-width: 899px) {
     align-items: flex-start;
-    margin: 0 20px;
+    padding: 0 50px;
+  }
+
+  @media (max-width: 375px) {
+    padding: 0 20px;
   }
 `;
 
@@ -51,7 +55,7 @@ const ContentWrapper = styled.div`
 
   /* 모바일 뷰 */
   @media (max-width: 899px) {
-    width: 360px;
+    width: 100%;
     padding: 76px 0;
   }
 `;


### PR DESCRIPTION
## Summary
- close #274 

## Screenshot
- 모바일 뷰에서 프로젝트 카드 서비스 이용 가능 및 창업 중 정보가 하단 오른쪽 자리(디자인 상 멤버 자리)에서 보여지고 있어서 왼쪽으로 이동
  ![image](https://github.com/sopt-makers/sopt.org-frontend/assets/63948884/df24866d-4411-4be9-87d0-424c05faf744)

- 프로젝트 제목 한 줄 이상 초과시 ellipsie 처리 되도록 수정
- **_저희 프로젝트 탭 모바일 뷰가 굉장히 이상하게 보이고 있습니다..!_** (아래 이미지 참고) 모바일 뷰 width가 `360px`으로 되어 있었는데 [5304bd8](https://github.com/sopt-makers/sopt.org-frontend/pull/264/commits/5304bd830b9759554299441033abe15a7f694b4c) 커밋에서 `align-items: flex-start` 속성이 부여되면서 이렇게 된걸로 보입니다. 그래서 width `360px` 고정을 풀고 그냥 디자인대로 화면 사이즈에 맞게 너비가 넓어지게 해놨습니다. 

  |수정 전|수정 후|
  |--|--|
  |![image](https://github.com/sopt-makers/sopt.org-frontend/assets/63948884/fc710ef1-c3a3-4747-97e9-8e614a28e9b4)|![image](https://github.com/sopt-makers/sopt.org-frontend/assets/63948884/86b20b84-84bc-4315-ba87-c28bfcf5fb60)|

- 추가적으로 위 사진을 보시면 아시겠지만 기존에는 디바이스가 모바일일 때만 화살표가 사라지고, PC 화면 사이즈가 `899px` 이하일 때는 화살표 및 블러가 남아있었는데 PC에서도 `899px` 이하가 되면 전부 안보이게 해놨습니다. 다만 캐러셀 하단의 하얀 동그라미 부분을 남겨놔서 PC에서도 슬라이드 이동이 가능하게 하였고, 모바일에서는 디자인대로 안보이게 해놨습니다.

  https://github.com/sopt-makers/sopt.org-frontend/assets/63948884/62b1d707-2844-4779-9ddb-5f9a458549b9

- 모바일 뷰 패딩을 `375px` 이하는 양 옆 `20px`, `899px~376px`은 `50px`로 주었습니다.

- 모바일 뷰 드롭다운이 피그마랑 폰트 사이즈 및 너비가 다른 것 같아 조정하였습니다. 

|수정 전|수정 후|
|--|--|
|![image](https://github.com/sopt-makers/sopt.org-frontend/assets/63948884/a40fd360-e4d6-4eaf-b9c4-eb0e71c74b38)|![image](https://github.com/sopt-makers/sopt.org-frontend/assets/63948884/877a5814-9f43-4155-8b6a-79578bfa016c)|

## Comment
- [dev](https://sopt-org-frontend-alpha.vercel.app/project) 페이지 참고
- 블로그 페이지와 프로젝트 페이지의 모바일 뷰 브레이크 포인트가 달라서 `Select` 컴포넌트에서 `page` 프로퍼티를 추가적으로 받았습니다. 상위 요소에서 한 번만 미디어 쿼리를 작성하고 싶었는데 클래스 네임을 이용하는 것 말고는 다른 방법이 떠오르지 않아 스타일드 컴포넌트에 프로퍼티를 일일이 넘겨줬습니다. 더 좋은 방법이 있으시면 코멘트 달아주시면 감사하겠습니다. 

- 서버 쪽에서 서비스 이용 가능 및 창업 중 정보가 안내려오고 있습니다. -> 문의할 예정