### PR TITLE
[SP2]블로그 모바일 탭 css 추가

### DIFF
--- a/src/views/BlogPage/components/BlogTab/style.ts
+++ b/src/views/BlogPage/components/BlogTab/style.ts
@@ -57,6 +57,8 @@ export const TabTitle = styled.article<{ isSelected: boolean }>`
   @media (max-width: 767px) {
     border-bottom: ${({ isSelected }) => isSelected && `1px solid ${colors.gray200}`};
     margin-right: 12px;
+    font-size: 18px;
+    padding-bottom: 6px;
   }
 
   &:hover {


### PR DESCRIPTION
## Summary
close #273 
블로그 모바일 탭 폰트 크기 css 가 누락되어 추가했습니다.

## Screenshot
|전|후|
|--|--|
|<img width="313" alt="image" src="https://github.com/sopt-makers/sopt.org-frontend/assets/62867581/2276ad1c-cf77-4687-9813-8d585d188e5e">|<img width="311" alt="image" src="https://github.com/sopt-makers/sopt.org-frontend/assets/62867581/dba7015a-57e8-43eb-b927-32a3b425c9df">|


## Comment
