### PR TITLE
[SP3] 모바일 메인 하단 백그라운드 제거

### DIFF
--- a/src/views/MainPage/components/BottomLayout/style.ts
+++ b/src/views/MainPage/components/BottomLayout/style.ts
@@ -14,7 +14,7 @@ export const Wrapper = styled(motion.section)`
   background-color: ${colors.white};
 
   @media (max-width: 768px) {
-    padding: 0 5.98vw;
+    padding: 0;
   }
 `;
 
@@ -92,7 +92,9 @@ export const Layout = styled(motion.div)`
   background: #f6f8fc;
 
   @media (max-width: 768px) {
+    width: 100%;
     padding: 65px 6.25vw 0 6.25vw;
+    border-radius: 20.946px 20.946px 0 0;
   }
 
   @media (max-width: 428px) {


### PR DESCRIPTION
## Summary
- close #329 

## Screenshot
- 768px 부터는 좌우 하얀색 여백을 제거합니다.

<img width="482" alt="image" src="https://github.com/sopt-makers/sopt.org-frontend/assets/63948884/36da88cc-3b3b-4427-bbfe-a4861ec4a65f">