### PR TITLE
[SP-] 배포 시 일부 페이지가 amplitude 오류로 렌더되지 않는 오류 수정

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -5,7 +5,7 @@ import type { AppProps } from 'next/app';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { Global } from '@emotion/react';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { ReactQueryDevtools } from 'react-query/devtools';
 import SEO from '@src/components/common/SEO';
@@ -28,12 +28,19 @@ export const queryClient = new QueryClient({
 });
 
 amplitude.add(pageViewTrackingEnrichment());
-amplitude.init(AMPLITUDE_API_KEY, {
-  logLevel: amplitude.Types.LogLevel.Warn,
-  defaultTracking: true,
-});
 
 function MyApp({ Component, pageProps }: AppProps) {
+  const [isAmplitudeInitialized, setIsAmplitudeInitialized] = useState(false);
+  useEffect(() => {
+    if (!isAmplitudeInitialized) {
+      amplitude.init(AMPLITUDE_API_KEY, {
+        logLevel: amplitude.Types.LogLevel.Warn,
+        defaultTracking: true,
+      });
+      setIsAmplitudeInitialized(true);
+    }
+  }, [isAmplitudeInitialized]);
+
   const router = useRouter();
   useEffect(() => {
     router.events.on('routeChangeComplete', gtm.pageview);


### PR DESCRIPTION
## Summary

기존 amplitude를 초기화하는 시점이 컴포넌트 바깥인데, 

이 경우 pages/project/[id] 에 있는 파일들이 구워질 때 에러가 발생합니다

정확한 원인은 모르지만, 일단 생명주기 안쪽으로 init하는 코드를 옮겨 문제를 해결하였습니다.

배포 전에 편할 때 develop으로 머지해 주세요!!