### PR TITLE
[Refactor] 소개페이지 상단 배너 로딩 속도 개선 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 16.x
-        uses: actions/setup-node@v1
+      - name: Use Node.js 18.x
+        uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: '18'
 
       - name: Install pnpm
         run: npm install -g pnpm@7.28.0

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -44,6 +44,7 @@ export const getStaticProps = async () => {
       aboutInfo,
       memberInfo,
     },
+    revalidate: 120,
   };
 };
 

--- a/src/views/AboutPage/components/Banner/index.tsx
+++ b/src/views/AboutPage/components/Banner/index.tsx
@@ -1,3 +1,4 @@
+import Image from 'next/image';
 import * as S from './style';
 
 interface BannerProps {
@@ -8,7 +9,19 @@ interface BannerProps {
 const Banner = (props: BannerProps) => {
   const { imageSrc } = props;
 
-  return <S.Banner src={imageSrc}></S.Banner>;
+  return (
+    <S.Banner>
+      <Image
+        src={imageSrc}
+        alt="SOPT banner"
+        fill
+        style={{
+          objectFit: 'cover',
+          objectPosition: 'center',
+        }}
+      />
+    </S.Banner>
+  );
 };
 
 export default Banner;

--- a/src/views/AboutPage/components/Banner/style.ts
+++ b/src/views/AboutPage/components/Banner/style.ts
@@ -1,10 +1,11 @@
 import styled from '@emotion/styled';
 
-export const Banner = styled.div<{ src: string }>`
+export const Banner = styled.div`
   width: 100vw;
   max-height: 630px;
   height: calc(376px + 13vw);
-  background: center / cover no-repeat url(${({ src }) => src});
+  position: relative;
+  overflow: hidden;
 
   /* 태블릿 뷰 */
   @media (max-width: 48rem) {


### PR DESCRIPTION
## Summary
- close #411 

소개페이지의 상단 배너 로딩 속도가 너무 느렸어요 
소개페이지의 가장 상단 콘텐츠이고 나름 메인 콘텐츠이기 때문에 개선이 시급한 친구라고 생각했습니다 ! 
(관련해서 아주 불편하다고 제보도 받았구요) 
해결책 고민하는 시간은 길었지만 결론적으로 작업한 코드는 정말 별거 없습니다 

- s3에 업로드되어있는 이미지 사이즈 수정 및 webp로 변환
- SSG 형식으로 불러오던 소개페이지 데이터를 ISR 형식으로 수정 (revalidate 간격 120초) 
- 상단 배너 element를 div 태그 -> next/image 컴포넌트로 수정 


## Screenshot
### 🪫 개선 전 
![image](https://github.com/user-attachments/assets/93253979-8ae1-4f81-b776-5f1d90ad923c)

레전드 쓰레기 LCP 발생 ! 

![image](https://github.com/user-attachments/assets/ddbe1019-b2b4-4439-a982-bd1b928ba891)


### 🔋 개선 후 
<img width="589" alt="image" src="https://github.com/user-attachments/assets/02596efe-878e-462b-9a83-dd7e082e26b4">
<img width="750" alt="image" src="https://github.com/user-attachments/assets/21b2c3a7-a926-4409-b0ad-0d7122e218a8">

**LCP 3.5초 줄임**으로써 Performance 지수를 약 **20점 올릴 수 있었습니다** 🤙🏻

## Comment

### 🐽 s3에 업로드되어있는 이미지 사이즈 수정 및 webp로 변환
우선 아시다시피 소개페이지의 상단 배너는 저희가 로컬 이미지를 넣어주는 형태가 아니라 s3에 저장되어있는 이미지를 서버에서 받아와서 remote url을 src로 넣어주는 형태입니다 
그런데 이 이미지 상태가 심각했어요 

![image](https://github.com/user-attachments/assets/b9338a25-5e07-43ed-99db-6e09b2a3a3f0)

렌더되는 너비는 100vw여서 가장 커봤자 2000px보다 작을텐데 
저 불러오는 원본 이미지 너비는 무려 16400px........파일 사이즈는 3.8MB....  거의 100배에 달하게 큰 이미지를 받고 있더라구요  
백엔드 개발자분이 피그마에서 이미지를 추출해갈때 화질 저하를 막기 위해 4배로 뽑아가신게 원인이었어요 

이게 가장 치명적인 문제였기에 
이미지 다시 리사이징하고 또 최적화를 위해 형식도 webp로 변환해서 백엔드분께 파일 변경을 부탁드렸습니다 

이미지 리사이징은 너비 `4000px`로 했어요. 2000px로 하니까 기존 배너보다 확실히 화질 저하가 발생하더라구요 
그래서 기존보다 최대한 화질 차이 안나는 선에서 최소한으로 줄인 크기가 4000px 였습니당 

무튼 그렇게 리사이징 + webp 변환해서 `3.8MB` -> `288KB`로 줄일 수 있었습니다 

<img width="250" alt="image" src="https://github.com/user-attachments/assets/2df0ae5f-6603-40ab-ae65-0d078231053f">

여기서 로딩 속도 개선 끝났다~ 싶었는데 별안간 이슈가 발생했어요 

### 🐽 SSG 형식으로 불러오던 소개페이지 데이터를 ISR 형식으로 수정 (revalidate 간격 120초) 

그 이슈는 ... 이미지 파일 갈아끼고 나서 데브 모드에서 빠르게 로딩되는거 확인하고 배포서버에도 반영해달라고 요청을 드렸는데 
**분명 서버에서는 이미지를 교체했는데 그게 저희 배포본에는 반영이 안되는거예요** 
브라우저 캐시 문제라고 생각해서 온갖 캐시 다 지우고 이 브라우저 저 브라우저에서 다 시도해보았는데 이미지는 절대 업데이트 되지 않았어요 

![image](https://github.com/user-attachments/assets/16553333-beda-4c27-8fd5-0c00d61019c1)

그래서 네트워크 탭으로 SSG로 불러오고 잇는 about.json을 찾아보니 
**vercel cache에 HIT를 치고있더라고요?** 

즉, 제가 삽질하고 있던 `브라우저 캐시`가 아닌, **SSG 사용으로 인한 `vercel 캐시`에 저장되어있던 친구였어요.** 

장황한 설명 생략하고 결론만 말씀드리면, 
**`Vercel`에 배포된 `Next` 배포본에서 `SSG`로 불러오는 데이터는 Vercel의 _next 캐시에 `영구적으로` 저장이 되어서,** 
이후 해당 캐시를 항상 사용한다고 하더라고요.
즉 재배포가 되기 전까지는 영구적으로 동일한 캐시데이터를 사용하게 되는거죠. (SSG의 효과가 바로 이 친구 덕분이겠죠?) 

그런데 SSG의 강점을 위해 제공하는 이 기능은 딱봐도 한계점이 보이죠. 
바로 제가 이번에 겪은 상황처럼 서버 데이터가 변경될 경우 이게 반영이 안된다는 점인데요, 
그 한계를 개선하기 위해 next13버전에서 등장한게 `ISR` **(Incremental Static Regeneration)** 이라고 합니다 

[나랑 같은 니즈를 가진 사람의 호소문](https://github.com/vercel/next.js/discussions/32975) 
[Lee Robinson 씨의 ISR 소개](https://www.youtube.com/watch?v=BGexHR1tuOA)

SSG의 장점은 최대한 가져가되, revalidate 주기를 지정해줘서 **주기적으로 해당 데이터를 update 시켜줄 수 있는 방식**입니다 

따라서 이 revalidate 옵션을 `2분`으로 설정해줌으로써 SSG -> ISR 방식으로 수정해서 
배포본(pnpm build -> ppm start)에서 갱신된 서버 데이터 잘 반영되는 것까지 확인했습니다!


궁금하실만한 부분 몇까지 더 첨언하자면 

- **❓왜하필 2분인가요?** 
  - 사실 소개페이지는 기존에 SSG를 썼던 만큼 잦은 업데이트가 전혀 불필요한 페이지예요. 다만 서버 데이터상의 변경이 생겼을 경우 이게 반영은 되어야 하니까 **너무 긴 주기를 주고 싶진 않았고**, 하지만 또 사용자가 접속하는 시간동안 서버 데이터가 바뀌는 일이 매우 드문건 사실이잖아요? 따라서 대부분의 경우에 **사용자가 참여하는 한 세션 동안 새로이 revalidate 하면서 불필요한 서버 요청을 일으키는 것도 피하고 싶었어요**. 그래서 GA로 사용자 체류시간을 봤는데 소개페이지는 평균 체류시간 약 50초, 전체 페이지 평균 체류 시간 약 1분 20초, 한달 내 최대 체류 시간 약 1분 50초 이길래 이보다 긴 2분으로 설정했습니다. 

- **❓근데 그럼 2분마다 데이터가 stale하게 된다면, 사용자가 새로 접속할 때마다 새로이 데이터를 불러오는건데 그럼 SSG의 효과가 떨어지는 것 아닌가?** 
  - 아니에요. SSG가 사용자 경험에 이득을 주는 부분은 미리 빌드해놓고 **캐시**에 저장되어있는 데이터를 해당 페이지 접속했을 때 딱 띄우기 때문에 빠르게 로드할 수 있다는 점인데요, ISR을 통해 stale한 데이터를 revalidate 해서 만약 데이터가 갱신되었을 경우, 사용자가 cache에서 MISS를 찍고 **새로이 서버에서 데이터를 가져오게 되면 SSG의 장점이 훼손되겠죠**? 그런데 **그게 아니라!** 갱신된 데이터는 백그라운드 상에서 **_next 캐시 저장소**에 반영되는 방식입니다. 즉 클라이언트 입장에서 사전에 빌드된 데이터를 **_next 캐시에서 가져오는 것은 그대로**고, revalidate은 백그라운드 상에서 진행되면서 캐시가 갱신되게 돼요.(즉 클라가 캐시를 MISS하는 케이스는 없는 것임) 따라서 사용자 경험 측면에서는 SSG나 ISR이나 **모두 동일한 효과를 유지해요.** 


내용이 다소 두서없을 수 있을 것 같아요 🥵🥵🥵... 
그리고 ISR에 대해 공유드리고 싶은 부분들이 더더 많이 남아있는데, PR에 다 정리하기에는 투머치인 것 같아서 여기까지만 작성해둘게요
관련해서는 금주 내로 아티클로 정리할 예정이라 아티클 완성되면 여기에 추가해놓겠습니다!! 


### 🐽 상단 배너 element를 div 태그 -> next/image 컴포넌트로 수정 
마지막 최적화 단계인데요, 
이미지 리사이징을 했지만 화질저하 때문에 여전히 큰 이미지를 가져오고 있기 때문에 
`next/image `컴포넌트를 사용해서 한번 더 리사이징 및 최적화를 해주었어요. 

기존에는 그냥 div 태그에 background-image로 삽입하는 형식으로 구현되어있더라구요? 
그런데 상단배너는 이미지 위에 별도의 콘텐츠가 있는 것도 아니라서 기존의 background 방식을 유지할 필요가 없었어요 

따라서 next/image 컴포넌트로 바꿔줌으로써 **화면에 fit한 사이즈로 리사이징해주며 한단계 더 최적화해주었습니다** 

이렇게 해서 최종적으로 `3.8MB`로 들어오던 file size를 **`5.2kB`까지 줄일 수 있게 되었어요 !** 

--- 
+) 노드 버전으로 인한 CI 에러 때문에 yml파일 수정해줬습니다 
