### PR TITLE
[Fix] sp1 blog qa 사항 반영

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5629,7 +5629,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3)(eslint@8.57.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -5651,7 +5651,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3)(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/src/components/common/Select/style.ts
+++ b/src/components/common/Select/style.ts
@@ -96,8 +96,6 @@ export const SelectTriggerContent = styled.p<{
 `;
 
 export const SelectItemContent = styled.p<{ isWide: boolean; breakPoint: string }>`
-  /* margin-right: ${({ isWide }) => isWide && '42px'}; */
-
   font-size: 16rem;
 
   @media (max-width: ${({ breakPoint }) => breakPoint}) {

--- a/src/components/common/Select/style.ts
+++ b/src/components/common/Select/style.ts
@@ -96,7 +96,7 @@ export const SelectTriggerContent = styled.p<{
 `;
 
 export const SelectItemContent = styled.p<{ isWide: boolean; breakPoint: string }>`
-  margin-right: ${({ isWide }) => isWide && '42px'};
+  /* margin-right: ${({ isWide }) => isWide && '42px'}; */
 
   font-size: 16rem;
 

--- a/src/views/BlogPage/components/BlogTab/style.ts
+++ b/src/views/BlogPage/components/BlogTab/style.ts
@@ -76,6 +76,10 @@ export const LayoutContainer = styled.div`
   position: relative;
   width: 100%;
   height: 48px;
+
+  @media (max-width: 375px) {
+    height: 38px;
+  }
 `;
 
 export const Layout = styled.div`

--- a/src/views/BlogPage/components/BlogTab/style.ts
+++ b/src/views/BlogPage/components/BlogTab/style.ts
@@ -96,6 +96,13 @@ export const Layout = styled.div`
 export const TagContainer = styled.section`
   display: flex;
   gap: 12px;
+
+  /* 모바일 뷰 */
+  @media (max-width: 375px) {
+    & > div > button {
+      max-height: 38px;
+    }
+  }
 `;
 
 export const Tag = styled.button<{ isSelected: boolean }>`
@@ -118,9 +125,21 @@ export const Tag = styled.button<{ isSelected: boolean }>`
   white-space: nowrap;
 
   cursor: pointer;
+
+  /* 모바일 뷰 */
+  @media (max-width: 375px) {
+    max-height: 38px;
+  }
 `;
 
 export const SelectContainer = styled.section`
   display: flex;
   gap: 16px;
+
+  /* 모바일 뷰 */
+  @media (max-width: 375px) {
+    & > div > button {
+      max-height: 38px;
+    }
+  }
 `;


### PR DESCRIPTION
## Summary
blog qa 반영했습니다. 

- 모바일 뷰에서 칩, 드롭다운 사이즈 작게 조정
디자인 상으로는 mds를 사용하고 있는데 공홈에서는 mds를 사용하지 않고 자체적으로 컴포넌트를 만들어서 사용하고 있었습니다.
그래서 mds를 설치하여 사용하려고 했는데 반응형 구현이 오히려 까다로워지는것 같아서 그냥 기존에 구현되어있던 컴포넌트에 반응형 처리를 해주었습니다.

- 모바일 뷰에서 “전체 활동” 옵션이 두줄로 보임 (활성화시 한 줄로 바뀜)
```ts
export const SelectItemContent = styled.p<{ isWide: boolean; breakPoint: string }>`
  /* margin-right: ${({ isWide }) => isWide && '42px'}; */
```
드롭다운 item 글자수가 5글자 이상인 경우 오른쪽 마진이 생기는 구조로 구현되어있습니다.
그래서 "전체 활동" 의 경우 오른쪽 마진이 생겨서 뷰가 확장되는 에러가 있었습니다.
드롭다운이 있는 뷰를 다 살펴봤는데 `isWide` 속성이 왜 있는지 모르겠어서 일단 주석처리 해주어 문제를 해결해주었습니다.
혹시 `isWide`에 대해서 아는게 있으시면 알려주시면 감사하겠습니다..!
## Screenshot

## Comment
