### PR TITLE
[Feat] breakpoints 및 media query 유틸 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ yarn-error.log*
 
 # env files
 .env.*
+
+# omc
+.omc

--- a/src/components/common/Select/index.tsx
+++ b/src/components/common/Select/index.tsx
@@ -1,7 +1,6 @@
 import { ComponentPropsWithoutRef, SVGProps, useCallback, useRef, useState } from 'react';
 import IcChevronDown from '@src/assets/icons/ic_chevron-down.svg';
 import useOutsideClickListener from '@src/hooks/useOutsideClickListener';
-import { Breakpoint } from '@src/lib/styles/breakpoints';
 import { LabelKeyType } from '@src/lib/types/universal';
 import * as S from './style';
 
@@ -13,7 +12,6 @@ type SelectProps<T extends LabelKeyType> = ComponentPropsWithoutRef<'div'> &
     selectedValue: T;
     setSelectedValue: (newValue: T) => void;
     labels: Record<T, string>;
-    breakPoint?: Breakpoint;
     variant?: 'round' | 'square';
     icon?: SVGProps<SVGSVGElement>;
   };
@@ -25,7 +23,6 @@ export default function Select<T extends LabelKeyType>({
   baseValue,
   baseLabel,
   labels,
-  breakPoint,
   variant = 'round',
   icon = IcChevronDown,
   ...props
@@ -54,13 +51,11 @@ export default function Select<T extends LabelKeyType>({
         isSelectionExist={selectedValue !== baseValue}
         isOpened={isOpen}
         isWide={currentSelectedValue.length >= 5}
-        breakPoint={breakPoint}
         variant={variant}
         {...props}
       >
         <S.SelectTriggerContent
           isSelectionExist={selectedValue !== baseValue}
-          breakPoint={breakPoint}
         >
           {selectedValue === baseValue ? baseLabel : currentSelectedValue}
         </S.SelectTriggerContent>
@@ -72,7 +67,6 @@ export default function Select<T extends LabelKeyType>({
           ref={selectItemWrapperRef}
           isWide={currentSelectedValue.length >= 5}
           variant={variant}
-          breakPoint={breakPoint}
           {...props}
         >
           {options.map((option, index) => (
@@ -84,7 +78,6 @@ export default function Select<T extends LabelKeyType>({
             >
               <S.SelectItemContent
                 isWide={currentSelectedValue.length >= 5}
-                breakPoint={breakPoint}
               >
                 {labels[option]}
               </S.SelectItemContent>

--- a/src/components/common/Select/index.tsx
+++ b/src/components/common/Select/index.tsx
@@ -1,6 +1,7 @@
 import { ComponentPropsWithoutRef, SVGProps, useCallback, useRef, useState } from 'react';
 import IcChevronDown from '@src/assets/icons/ic_chevron-down.svg';
 import useOutsideClickListener from '@src/hooks/useOutsideClickListener';
+import { Breakpoint } from '@src/lib/styles/breakpoints';
 import { LabelKeyType } from '@src/lib/types/universal';
 import * as S from './style';
 
@@ -12,7 +13,7 @@ type SelectProps<T extends LabelKeyType> = ComponentPropsWithoutRef<'div'> &
     selectedValue: T;
     setSelectedValue: (newValue: T) => void;
     labels: Record<T, string>;
-    breakPoint: string;
+    breakPoint?: Breakpoint;
     variant?: 'round' | 'square';
     icon?: SVGProps<SVGSVGElement>;
   };

--- a/src/components/common/Select/style.ts
+++ b/src/components/common/Select/style.ts
@@ -2,13 +2,12 @@ import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
 import { css } from '@emotion/react';
 import { SVGProps } from 'react';
-import { Breakpoint, media } from '@src/lib/styles/breakpoints';
+import { media } from '@src/lib/styles/breakpoints';
 
 export const SelectTrigger = styled.button<{
   isSelectionExist: boolean;
   isOpened: boolean;
   isWide: boolean;
-  breakPoint?: Breakpoint;
   variant: 'round' | 'square';
 }>`
   display: flex;
@@ -40,18 +39,14 @@ export const SelectTrigger = styled.button<{
           background-color: ${colors.gray800};
         `}
 
-  ${({ breakPoint }) =>
-    breakPoint &&
-    css`
-      ${media[breakPoint]} {
-        min-width: 76px;
-        padding: 8px 12px;
-        border-radius: 99px;
-        font-size: 13rem;
-        line-height: 150%;
-        letter-spacing: -0.13px;
-      }
-    `}
+  ${media.tablet} {
+    min-width: 76px;
+    padding: 8px 12px;
+    border-radius: 99px;
+    font-size: 13rem;
+    line-height: 150%;
+    letter-spacing: -0.13px;
+  }
 `;
 
 export const Arrow = styled.div<{
@@ -87,7 +82,6 @@ export const SelectItem = styled.div<{ isSelected: boolean; variant: 'round' | '
 
 export const SelectTriggerContent = styled.p<{
   isSelectionExist: boolean;
-  breakPoint?: Breakpoint;
 }>`
   color: ${({ isSelectionExist }) => (isSelectionExist ? colors.white : colors.gray200)};
   margin-right: 8px;
@@ -95,31 +89,24 @@ export const SelectTriggerContent = styled.p<{
   font-weight: 500;
   white-space: nowrap;
 
-  ${({ breakPoint }) =>
-    breakPoint &&
-    css`
-      ${media[breakPoint]} {
-        font-size: 13rem;
-      }
-    `}
+  ${media.tablet} {
+    font-size: 13rem;
+  }
 `;
 
-export const SelectItemContent = styled.p<{ isWide: boolean; breakPoint?: Breakpoint }>`
+export const SelectItemContent = styled.p<{ isWide: boolean }>`
   font-size: 16rem;
 
-  ${({ breakPoint, isWide }) =>
-    breakPoint &&
-    css`
-      ${media[breakPoint]} {
-        margin-right: ${isWide && '22px'};
-        font-size: 13rem;
-      }
-    `}
+  ${({ isWide }) => css`
+    ${media.tablet} {
+      margin-right: ${isWide && '22px'};
+      font-size: 13rem;
+    }
+  `}
 `;
 
 export const SelectItemWrapper = styled.div<{
   isWide: boolean;
-  breakPoint?: Breakpoint;
   variant: 'round' | 'square';
 }>`
   display: flex;
@@ -174,11 +161,7 @@ export const SelectItemWrapper = styled.div<{
       }
     `}
 
-  ${({ breakPoint }) =>
-    breakPoint &&
-    css`
-      ${media[breakPoint]} {
-        min-width: 76px;
-      }
-    `}
+  ${media.tablet} {
+    min-width: 76px;
+  }
 `;

--- a/src/components/common/Select/style.ts
+++ b/src/components/common/Select/style.ts
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
 import { css } from '@emotion/react';
 import { SVGProps } from 'react';
-import { media, Breakpoint } from '@src/lib/styles/breakpoints';
+import { Breakpoint, media } from '@src/lib/styles/breakpoints';
 
 export const SelectTrigger = styled.button<{
   isSelectionExist: boolean;

--- a/src/components/common/Select/style.ts
+++ b/src/components/common/Select/style.ts
@@ -2,12 +2,13 @@ import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
 import { css } from '@emotion/react';
 import { SVGProps } from 'react';
+import { media, Breakpoint } from '@src/lib/styles/breakpoints';
 
 export const SelectTrigger = styled.button<{
   isSelectionExist: boolean;
   isOpened: boolean;
   isWide: boolean;
-  breakPoint: string;
+  breakPoint?: Breakpoint;
   variant: 'round' | 'square';
 }>`
   display: flex;
@@ -39,14 +40,18 @@ export const SelectTrigger = styled.button<{
           background-color: ${colors.gray800};
         `}
 
-  @media (max-width: ${({ breakPoint }) => breakPoint}) {
-    min-width: 76px;
-    padding: 8px 12px;
-    border-radius: 99px;
-    font-size: 13rem;
-    line-height: 150%;
-    letter-spacing: -0.13px;
-  }
+  ${({ breakPoint }) =>
+    breakPoint &&
+    css`
+      ${media[breakPoint]} {
+        min-width: 76px;
+        padding: 8px 12px;
+        border-radius: 99px;
+        font-size: 13rem;
+        line-height: 150%;
+        letter-spacing: -0.13px;
+      }
+    `}
 `;
 
 export const Arrow = styled.div<{
@@ -82,7 +87,7 @@ export const SelectItem = styled.div<{ isSelected: boolean; variant: 'round' | '
 
 export const SelectTriggerContent = styled.p<{
   isSelectionExist: boolean;
-  breakPoint: string;
+  breakPoint?: Breakpoint;
 }>`
   color: ${({ isSelectionExist }) => (isSelectionExist ? colors.white : colors.gray200)};
   margin-right: 8px;
@@ -90,23 +95,31 @@ export const SelectTriggerContent = styled.p<{
   font-weight: 500;
   white-space: nowrap;
 
-  @media (max-width: ${({ breakPoint }) => breakPoint}) {
-    font-size: 13rem;
-  }
+  ${({ breakPoint }) =>
+    breakPoint &&
+    css`
+      ${media[breakPoint]} {
+        font-size: 13rem;
+      }
+    `}
 `;
 
-export const SelectItemContent = styled.p<{ isWide: boolean; breakPoint: string }>`
+export const SelectItemContent = styled.p<{ isWide: boolean; breakPoint?: Breakpoint }>`
   font-size: 16rem;
 
-  @media (max-width: ${({ breakPoint }) => breakPoint}) {
-    margin-right: ${({ isWide }) => isWide && '22px'};
-    font-size: 13rem;
-  }
+  ${({ breakPoint, isWide }) =>
+    breakPoint &&
+    css`
+      ${media[breakPoint]} {
+        margin-right: ${isWide && '22px'};
+        font-size: 13rem;
+      }
+    `}
 `;
 
 export const SelectItemWrapper = styled.div<{
   isWide: boolean;
-  breakPoint: string;
+  breakPoint?: Breakpoint;
   variant: 'round' | 'square';
 }>`
   display: flex;
@@ -161,7 +174,11 @@ export const SelectItemWrapper = styled.div<{
       }
     `}
 
-  @media (max-width: ${({ breakPoint }) => breakPoint}) {
-    min-width: 76px;
-  }
+  ${({ breakPoint }) =>
+    breakPoint &&
+    css`
+      ${media[breakPoint]} {
+        min-width: 76px;
+      }
+    `}
 `;

--- a/src/lib/constants/project.ts
+++ b/src/lib/constants/project.ts
@@ -1,3 +1,7 @@
+import projectThumbnail1 from '@src/assets/images/img_project_thumbnail1.png';
+import projectThumbnail2 from '@src/assets/images/img_project_thumbnail2.png';
+import projectThumbnail3 from '@src/assets/images/img_project_thumbnail3.png';
+import projectThumbnail4 from '@src/assets/images/img_project_thumbnail4.png';
 import { default as ImgProjectLogo1 } from '@src/assets/images/recent-release-project/img_project_logo1.avif';
 import { default as ImgProjectLogo2 } from '@src/assets/images/recent-release-project/img_project_logo2.avif';
 import {
@@ -6,12 +10,6 @@ import {
   ProjectPlatformType,
   StaticProjectType,
 } from '@src/lib/types/project';
-import { PageType } from '@src/lib/types/universal';
-
-import projectThumbnail1 from '@src/assets/images/img_project_thumbnail1.png';
-import projectThumbnail2 from '@src/assets/images/img_project_thumbnail2.png';
-import projectThumbnail3 from '@src/assets/images/img_project_thumbnail3.png';
-import projectThumbnail4 from '@src/assets/images/img_project_thumbnail4.png';
 
 export const activeProjectCategoryList: ProjectCategoryType[] = [
   ProjectCategoryType.ALL,
@@ -49,11 +47,6 @@ export const projectPlatformLabel: Record<ProjectPlatformType, string> = {
   [ProjectPlatformType.WEB]: '웹',
 };
 
-export const pageBreakPoint: Record<PageType, string> = {
-  [PageType.BLOG]: '767px',
-  [PageType.PROJECT]: '899px',
-};
-
 export const staticReleaseProjectList: StaticProjectType[] = [
   {
     name: '엄빠도 어렸다',
@@ -87,11 +80,11 @@ export const staticReleaseProjectList: StaticProjectType[] = [
 
 export const MAIN_PROJECT_LIST = [
   {
-
     thumbnail: projectThumbnail1.src,
     title: 'ELFISODE',
     category: 'APP',
-    description: '익명으로 마음을 털어놓고, 또래의 이야기를 받아볼 수 있는\n아이슬란드 청소년 감정 공유 플랫폼',
+    description:
+      '익명으로 마음을 털어놓고, 또래의 이야기를 받아볼 수 있는\n아이슬란드 청소년 감정 공유 플랫폼',
     status: '',
     members: 10,
   },
@@ -99,7 +92,8 @@ export const MAIN_PROJECT_LIST = [
     thumbnail: projectThumbnail2.src,
     title: 'Walkie',
     category: 'APP',
-    description: '걷기와 헬스케어를 결합해 일상을 더 건강하고 재미있게 즐길\n수 있도록 돕는 서비스입니다.',
+    description:
+      '걷기와 헬스케어를 결합해 일상을 더 건강하고 재미있게 즐길\n수 있도록 돕는 서비스입니다.',
     status: '서비스 이용 가능',
     members: 4,
   },

--- a/src/lib/styles/breakpoints.ts
+++ b/src/lib/styles/breakpoints.ts
@@ -5,7 +5,7 @@ export const breakpoints = {
   desktopLarge: '2560px',
 } as const;
 
-export type Breakpoint = keyof typeof breakpoints;
+export type Breakpoint = keyof typeof media;
 
 export const media = {
   mobile: `@media (max-width: ${breakpoints.mobile})`,

--- a/src/lib/styles/breakpoints.ts
+++ b/src/lib/styles/breakpoints.ts
@@ -1,14 +1,15 @@
 export const breakpoints = {
-  mobile: '767px',
-  tablet: '1023px',
-  desktop: '1260px',
-  desktopLarge: '2560px',
+  mobile: 0,
+  tablet: 768,
+  desktop: 1024,
+  desktopLarge: 1260,
+} as const;
+
+export const media = {
+  mobile: `@media (max-width: ${breakpoints.tablet - 1}px)`,
+  tablet: `@media (min-width: ${breakpoints.tablet}px) and (max-width: ${breakpoints.desktop - 1}px)`,
+  desktop: `@media (min-width: ${breakpoints.desktop}px) and (max-width: ${breakpoints.desktopLarge - 1}px)`,
+  desktopLarge: `@media (min-width: ${breakpoints.desktopLarge}px)`,
 } as const;
 
 export type Breakpoint = keyof typeof media;
-
-export const media = {
-  mobile: `@media (max-width: ${breakpoints.mobile})`,
-  tablet: `@media (max-width: ${breakpoints.tablet})`,
-  desktopLarge: `@media (min-width: ${breakpoints.desktop}) and (max-width: ${breakpoints.desktopLarge})`,
-} as const;

--- a/src/lib/styles/breakpoints.ts
+++ b/src/lib/styles/breakpoints.ts
@@ -1,0 +1,14 @@
+export const breakpoints = {
+  mobile: '767px',
+  tablet: '1023px',
+  desktop: '1260px',
+  desktopLarge: '2560px',
+} as const;
+
+export type Breakpoint = keyof typeof breakpoints;
+
+export const media = {
+  mobile: `@media (max-width: ${breakpoints.mobile})`,
+  tablet: `@media (max-width: ${breakpoints.tablet})`,
+  desktopLarge: `@media (min-width: ${breakpoints.desktop}) and (max-width: ${breakpoints.desktopLarge})`,
+} as const;

--- a/src/views/BlogPage/components/BlogPostList/index.tsx
+++ b/src/views/BlogPage/components/BlogPostList/index.tsx
@@ -2,10 +2,8 @@ import { useState } from 'react';
 import IcSort from '@src/assets/icons/ic_sort.svg';
 import Pagination from '@src/components/common/Pagination';
 import Select from '@src/components/common/Select';
-import { pageBreakPoint } from '@src/lib/constants/project';
 import { sortLabel, sortValues } from '@src/lib/constants/tabs';
 import { BlogCategoryType, SortType } from '@src/lib/types/blog';
-import { PageType } from '@src/lib/types/universal';
 import BlogPost from '@src/views/BlogPage/components/BlogPost';
 import EmptyBlogPostList from '@src/views/BlogPage/components/EmptyBlogPostList';
 import OfficialVideo from '@src/views/BlogPage/components/OfficialVideo';
@@ -69,7 +67,7 @@ export default function BlogPostList({
                     selectedValue={selectedSort}
                     setSelectedValue={setSelectedSort}
                     labels={sortLabel}
-                    breakPoint={pageBreakPoint[PageType.PROJECT]}
+                    breakPoint="tablet"
                     variant="square"
                     icon={IcSort}
                     style={{ minWidth: '160px' }}

--- a/src/views/BlogPage/components/BlogPostList/index.tsx
+++ b/src/views/BlogPage/components/BlogPostList/index.tsx
@@ -67,7 +67,6 @@ export default function BlogPostList({
                     selectedValue={selectedSort}
                     setSelectedValue={setSelectedSort}
                     labels={sortLabel}
-                    breakPoint="tablet"
                     variant="square"
                     icon={IcSort}
                     style={{ minWidth: '160px' }}

--- a/src/views/BlogPage/components/BlogTab/index.tsx
+++ b/src/views/BlogPage/components/BlogTab/index.tsx
@@ -93,7 +93,6 @@ export default function BlogTab({
                       selectedValue={selectedActivity}
                       setSelectedValue={setSelectedActivity}
                       baseValue={ActivitySelectType.ALL}
-                      breakPoint={'0px'}
                       variant="square"
                     />
                   )}
@@ -106,7 +105,6 @@ export default function BlogTab({
                     selectedValue={selectedMajorCategory}
                     setSelectedValue={setMajorCategory}
                     baseValue={activeGenerationCategoryList[0]}
-                    breakPoint={'0px'}
                     variant="square"
                   />
                   <Select
@@ -116,7 +114,6 @@ export default function BlogTab({
                     selectedValue={selectedSubCategory}
                     setSelectedValue={setSubCategory}
                     baseValue={PartCategoryType.ALL}
-                    breakPoint={'0px'}
                     variant="square"
                   />
                 </S.SelectContainer>

--- a/src/views/ProjectPage/index.tsx
+++ b/src/views/ProjectPage/index.tsx
@@ -46,7 +46,6 @@ function Projects() {
               selectedValue={selectedCategory}
               setSelectedValue={setCategory}
               baseValue={ProjectCategoryType.ALL}
-              breakPoint="tablet"
             />
             <Select
               options={activeProjectPlatformList}
@@ -55,7 +54,6 @@ function Projects() {
               selectedValue={selectedPlatform}
               setSelectedValue={setPlatform}
               baseValue={ProjectPlatformType.ALL}
-              breakPoint="tablet"
             />
           </S.FilterWrapper>
           <Suspense fallback={<ProjectListFallback />}>

--- a/src/views/ProjectPage/index.tsx
+++ b/src/views/ProjectPage/index.tsx
@@ -6,12 +6,10 @@ import useStorage from '@src/hooks/useStorage';
 import {
   activeProjectCategoryList,
   activeProjectPlatformList,
-  pageBreakPoint,
   projectCategoryLabel,
   projectPlatformLabel,
 } from '@src/lib/constants/project';
 import { ProjectCategoryType, ProjectPlatformType } from '@src/lib/types/project';
-import { PageType } from '@src/lib/types/universal';
 import { ProjectList } from '@src/views/ProjectPage/components/project/ProjectList';
 import ProjectListFallback from '@src/views/ProjectPage/components/project/ProjectListFallback';
 import S from './styles';
@@ -48,7 +46,7 @@ function Projects() {
               selectedValue={selectedCategory}
               setSelectedValue={setCategory}
               baseValue={ProjectCategoryType.ALL}
-              breakPoint={pageBreakPoint[PageType.PROJECT]}
+              breakPoint="tablet"
             />
             <Select
               options={activeProjectPlatformList}
@@ -57,7 +55,7 @@ function Projects() {
               selectedValue={selectedPlatform}
               setSelectedValue={setPlatform}
               baseValue={ProjectPlatformType.ALL}
-              breakPoint={pageBreakPoint[PageType.PROJECT]}
+              breakPoint="tablet"
             />
           </S.FilterWrapper>
           <Suspense fallback={<ProjectListFallback />}>


### PR DESCRIPTION
## Summary

- `src/lib/styles/breakpoints.ts` 에 공통 breakpoint 상수 및 `media` 유틸 추가
- `Select` 컴포넌트의 `breakPoint` prop 타입을 `string` → `Breakpoint` (optional)으로 변경

### breakpoints / media 사용법

**breakpoints.ts 구조**
```ts
export const breakpoints = {
  mobile: '767px',
  tablet: '1023px',
  desktop: '1260px',
  desktopLarge: '2560px',
} as const;

export type Breakpoint = keyof typeof breakpoints;

export const media = {
  mobile: `@media (max-width: ${breakpoints.mobile})`,
  tablet: `@media (max-width: ${breakpoints.tablet})`,
  desktopLarge: `@media (min-width: ${breakpoints.desktop}) and (max-width: ${breakpoints.desktopLarge})`,
} as const;
```

**styled-components에서 사용 예시**
```ts
import { media } from '@src/lib/styles/breakpoints';

const Box = styled.div`
  font-size: 16px;

  ${media.tablet} {
    font-size: 14px;
  }

  ${media.mobile} {
    font-size: 12px;
  }
`;
```

**Select 컴포넌트에서 사용 예시**
```tsx
import { Breakpoint } from '@src/lib/styles/breakpoints';

// breakPoint는 optional — 반응형이 필요 없는 경우 생략 가능
<Select breakPoint="tablet" ... />
<Select ... /> // breakPoint 없이도 동작
```

## Comment

- `media` 객체에 키를 추가하면 새로운 breakpoint를 바로 사용할 수 있습니다.
- raw string 대신 `Breakpoint` 타입을 사용해 오타를 방지합니다.