### PR TITLE
[Feat] Project section 구현

### DIFF
--- a/src/views/MainPage/components/@common/Button/style.ts
+++ b/src/views/MainPage/components/@common/Button/style.ts
@@ -1,19 +1,18 @@
 import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
+import { fontsObject } from '@sopt-makers/fonts';
 
 export const Button = styled.button`
   display: flex;
   width: fit-content;
   align-items: center;
   justify-content: center;
-  padding: 16px 26px;
-  border-radius: 12px;
+  padding: 12px 20px;
+  border-radius: 10px;
   border: 1px solid ${colors.white};
   gap: 4px;
-  font-size: 18px;
-  font-weight: 600;
-  line-height: 24px;
-  letter-spacing: -0.4px;
+
+  ${fontsObject.TITLE_6_16_SB}
   color: ${colors.white};
   cursor: pointer;
   transition: all 0.3s ease;
@@ -23,17 +22,13 @@ export const Button = styled.button`
     color: ${colors.black};
   }
 
-  /* 태블릿 뷰 */
-  @media (max-width: 1023px){
-    padding: 12px 20px;
-    font-size: 16px;
-    line-height: 24px;
+  @media (max-width: 1023px) {
+    padding: 9px 14px;
+    ${fontsObject.LABEL_3_14_SB}
   }
 
-  /* 모바일 뷰 */
   @media (max-width: 767px) {
     padding: 9px 14px;
-    font-size: 14px;
-    line-height: 18px;
+    ${fontsObject.LABEL_3_14_SB}
   }
 `;

--- a/src/views/MainPage/components/@common/Button/style.ts
+++ b/src/views/MainPage/components/@common/Button/style.ts
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
 import { fontsObject } from '@sopt-makers/fonts';
+import { media } from '@src/lib/styles/breakpoints';
 
 export const Button = styled.button`
   display: flex;
@@ -22,12 +23,12 @@ export const Button = styled.button`
     color: ${colors.black};
   }
 
-  @media (max-width: 1023px) {
+  ${media.tablet} {
     padding: 9px 14px;
     ${fontsObject.LABEL_3_14_SB}
   }
 
-  @media (max-width: 767px) {
+  ${media.mobile} {
     padding: 9px 14px;
     ${fontsObject.LABEL_3_14_SB}
   }

--- a/src/views/MainPage/components/IntroSection/ProjectSection/Project/index.tsx
+++ b/src/views/MainPage/components/IntroSection/ProjectSection/Project/index.tsx
@@ -1,40 +1,35 @@
+import { useRouter } from 'next/router';
 import * as S from './style';
-import icMembers from '@src/assets/icons/ic_members.svg';
 
 interface ProjectProps {
   thumbnail: string;
   title: string;
   category: string;
   description: string;
-  status: string; 
-  members: number;
+  isActive: boolean;
+  href: string;
 }
 
-export default function Project({ thumbnail, title, category, description, status, members }: ProjectProps) {
-  return (
-    <S.Wrapper>
-      <S.Thumbnail src={thumbnail} alt={title} />
+export default function Project({
+  thumbnail,
+  title,
+  category,
+  description,
+  isActive,
+  href,
+}: ProjectProps) {
+  const router = useRouter();
 
+  return (
+    <S.Wrapper $isActive={isActive} onClick={() => router.push(href)}>
+      <S.Thumbnail src={thumbnail} alt={title} $isActive={isActive} />
       <S.ContentWrapper>
         <S.TitleWrapper>
-          <S.Title>{title}</S.Title>
-          <S.Category>{category}</S.Category>
+          <S.Title $isActive={isActive}>{title}</S.Title>
+          <S.Category $isActive={isActive}>{category}</S.Category>
         </S.TitleWrapper>
-        <S.Description>{description}</S.Description>
+        <S.Description $isActive={isActive}>{description}</S.Description>
       </S.ContentWrapper>
-      
-      <S.FooterLayout> 
-        {status !== '' && (
-        <S.StatusLayout>
-          <S.StatusCircle />
-          <S.Status>{status}</S.Status>
-        </S.StatusLayout> 
-        )}
-        <S.Members>
-          <S.MembersIcon src={icMembers} alt="members" aria-hidden="true" />
-          {members} members
-        </S.Members>
-      </S.FooterLayout>
     </S.Wrapper>
   );
 }

--- a/src/views/MainPage/components/IntroSection/ProjectSection/Project/style.ts
+++ b/src/views/MainPage/components/IntroSection/ProjectSection/Project/style.ts
@@ -1,154 +1,109 @@
 import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
+import { fontsObject } from '@sopt-makers/fonts';
+import { media } from '@src/lib/styles/breakpoints';
+import { ACTIVE_CARD_WIDTH, INACTIVE_CARD_WIDTH, MOBILE_CARD_WIDTH } from '../constants';
 
-export const Wrapper = styled.article`
+export const Wrapper = styled.article<{ $isActive: boolean }>`
+  flex-shrink: 0;
   display: flex;
-  width: 352px;
   flex-direction: column;
-  padding: 14px;
-  gap: 10px;
-  border: 1px solid ${colors.gray700};
-  border-radius: 20px;
   background-color: ${colors.gray900};
+  cursor: pointer;
+  transition: width 0.4s cubic-bezier(0.4, 0, 0.2, 1), height 0.4s cubic-bezier(0.4, 0, 0.2, 1),
+    padding 0.4s cubic-bezier(0.4, 0, 0.2, 1), border-radius 0.4s cubic-bezier(0.4, 0, 0.2, 1);
 
-  @media (max-width: 1023px) {
-    width: 176px;
-    height: 172.5px;
-    padding: 7px;
-    gap: 4px;
-    border-radius: 10px;
+  ${({ $isActive }) =>
+    $isActive
+      ? `
+    width: ${ACTIVE_CARD_WIDTH}px;
+    height: 448px;
+    gap: 14px;
+    padding: 24px 24px 48px;
+    border-radius: 32px;
+  `
+      : `
+    width: ${INACTIVE_CARD_WIDTH}px;
+    height: 324px;
+    gap: 16px;
+    padding: 16px;
+    border-radius: 24px;
+  `}
+
+  ${media.mobile} {
+    width: ${MOBILE_CARD_WIDTH}px;
+    height: auto;
+    gap: 14px;
+    padding: 16px 24px;
+    border-radius: 32px;
   }
 `;
 
-export const Thumbnail = styled.img`
-  width: 324px;
-  height: 192px;
-  border-radius: 8px;
+export const Thumbnail = styled.img<{ $isActive: boolean }>`
+  width: 100%;
   object-fit: cover;
+  flex-shrink: 0;
+  transition: height 0.4s cubic-bezier(0.4, 0, 0.2, 1),
+    border-radius 0.4s cubic-bezier(0.4, 0, 0.2, 1);
 
-  @media (max-width: 1023px) {
-    width: 162px;
-    height: 96px;
-    border-radius: 4px;
-  } 
+  ${({ $isActive }) =>
+    $isActive
+      ? `
+    height: 270px;
+    border-radius: 12px;
+  `
+      : `
+    height: 192px;
+    border-radius: 8px;
+  `}
+
+  ${media.mobile} {
+    height: 154px;
+    border-radius: 12px;
+  }
 `;
 
 export const ContentWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 10px;
-
-  @media (max-width: 1023px) {
-    gap: 4px;
-  }
+  gap: 6px;
 `;
 
 export const TitleWrapper = styled.div`
   display: flex;
   align-items: center;
-  gap: 3px;
+  gap: 8px;
 `;
 
-export const Title = styled.h1`
-  font-size: 18px;
-  font-weight: 700;
-  line-height: 28px;
-  color: ${colors.white};
+export const Title = styled.h3<{ $isActive: boolean }>(({ $isActive }) => ({
+  color: colors.white,
+  ...($isActive ? fontsObject.HEADING_4_24_B : fontsObject.HEADING_6_18_B),
 
-  @media (max-width: 1023px) {
-    font-size: 9px;
-    line-height: 14px;
-  }
+  [media.mobile]: {
+    ...fontsObject.HEADING_7_16_B,
+  },
+}));
 
-`;
+export const Category = styled.p<{ $isActive: boolean }>(({ $isActive }) => ({
+  color: colors.gray400,
+  ...($isActive ? fontsObject.TITLE_6_16_SB : fontsObject.LABEL_4_12_SB),
 
-export const Category = styled.p`
-  font-size: 12px;
-  font-weight: 600;
-  line-height: 16px;
-  color: ${colors.gray400};
+  [media.mobile]: {
+    ...fontsObject.LABEL_4_12_SB,
+  },
+}));
 
-  @media (max-width: 1023px) {
-    font-size: 6px;
-    line-height: 8px;
-  }
+export const Description = styled.p<{ $isActive: boolean }>(({ $isActive }) => ({
+  color: colors.gray50,
+  ...($isActive ? fontsObject.TITLE_4_20_SB : fontsObject.BODY_3_14_R),
+  ...(!$isActive && {
+    display: '-webkit-box',
+    WebkitLineClamp: 3,
+    WebkitBoxOrient: 'vertical',
+    overflow: 'hidden',
+  }),
 
-`;
-
-export const Description = styled.p`
-  font-size: 13px;
-  font-weight: 400;
-  line-height: 20px;
-  color: ${colors.gray50};
-  white-space: pre-line;
-
-  @media (max-width: 1023px) {
-    font-size: 7px;
-    line-height: 11px;
-    white-space: normal;
-  }
-`;
-
-export const StatusLayout = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 4px;
-`;
-
-export const StatusCircle = styled.div`
-  width: 5px;
-  height: 5px;
-  background-color: ${colors.information};
-  border-radius: 50%;
-  border: 1px solid ${colors.information};
-`;
-
-export const FooterLayout = styled.div`
-  display: flex;
-  width: 100%;
-  justify-content: space-between;
-  align-items: center;
-`;
-
-export const Status = styled.p` 
-  font-size: 12px;
-  font-weight: 600;
-  line-height: 16px;
-  color: ${colors.gray100};
-  white-space: nowrap;
-
-  @media (max-width: 1023px) {
-    font-size: 6px;
-    line-height: 8px;
-  }
-`;
-
-export const Members = styled.p`
-  display: flex;
-  width: 100%;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 4px;
-  font-size: 12px;
-  font-weight: 600;
-  line-height: 16px;
-  color: ${colors.white};
-
-  @media (max-width: 1023px) {
-    font-size: 6px;
-    line-height: 8px;
-  }
-`;
-
-export const MembersIcon = styled.img`
-  display: inline-block;
-  width: 72px;
-  height: 30px;
-  object-fit: contain;
-  flex-shrink: 0;
-
-  @media (max-width: 1023px) {
-    width: 36px;
-    height: 15px;
-  }
-`;
+  [media.mobile]: {
+    ...fontsObject.BODY_3_14_M,
+  },
+}));

--- a/src/views/MainPage/components/IntroSection/ProjectSection/Project/style.ts
+++ b/src/views/MainPage/components/IntroSection/ProjectSection/Project/style.ts
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
 import { fontsObject } from '@sopt-makers/fonts';
 import { media } from '@src/lib/styles/breakpoints';
-import { ACTIVE_CARD_WIDTH, INACTIVE_CARD_WIDTH, MOBILE_CARD_WIDTH } from '../constants';
+import { CARD_WIDTHS } from '../constants';
 
 export const Wrapper = styled.article<{ $isActive: boolean }>`
   flex-shrink: 0;
@@ -16,14 +16,14 @@ export const Wrapper = styled.article<{ $isActive: boolean }>`
   ${({ $isActive }) =>
     $isActive
       ? `
-    width: ${ACTIVE_CARD_WIDTH}px;
+    width: ${CARD_WIDTHS.desktop.active}px;
     height: 448px;
     gap: 14px;
     padding: 24px 24px 48px;
     border-radius: 32px;
   `
       : `
-    width: ${INACTIVE_CARD_WIDTH}px;
+    width: ${CARD_WIDTHS.desktop.inactive}px;
     height: 324px;
     gap: 16px;
     padding: 16px;
@@ -31,7 +31,7 @@ export const Wrapper = styled.article<{ $isActive: boolean }>`
   `}
 
   ${media.mobile} {
-    width: ${MOBILE_CARD_WIDTH}px;
+    width: ${CARD_WIDTHS.mobile.active}px;
     height: auto;
     gap: 14px;
     padding: 16px 24px;

--- a/src/views/MainPage/components/IntroSection/ProjectSection/constants.ts
+++ b/src/views/MainPage/components/IntroSection/ProjectSection/constants.ts
@@ -1,0 +1,12 @@
+export const CAROUSEL_GAP = 24;
+
+export const ACTIVE_CARD_WIDTH = 500;
+export const INACTIVE_CARD_WIDTH = 356;
+export const MOBILE_CARD_WIDTH = 280;
+
+export const CONTAINER_WIDTHS = {
+  mobile: 280,
+  tablet: 688,
+  desktop: 944,
+  desktopLarge: 1200,
+} as const;

--- a/src/views/MainPage/components/IntroSection/ProjectSection/constants.ts
+++ b/src/views/MainPage/components/IntroSection/ProjectSection/constants.ts
@@ -1,8 +1,9 @@
 export const CAROUSEL_GAP = 24;
 
-export const ACTIVE_CARD_WIDTH = 500;
-export const INACTIVE_CARD_WIDTH = 356;
-export const MOBILE_CARD_WIDTH = 280;
+export const CARD_WIDTHS = {
+  mobile: { active: 280, inactive: 280 },
+  desktop: { active: 500, inactive: 356 },
+} as const;
 
 export const CONTAINER_WIDTHS = {
   mobile: 280,

--- a/src/views/MainPage/components/IntroSection/ProjectSection/index.tsx
+++ b/src/views/MainPage/components/IntroSection/ProjectSection/index.tsx
@@ -9,11 +9,9 @@ import { ProjectCategoryType, ProjectPlatformType } from '@src/lib/types/project
 import SectionTop from '@src/views/AboutPage/components/@common/SectionTop';
 import Project from './Project';
 import {
-  ACTIVE_CARD_WIDTH,
+  CARD_WIDTHS,
   CAROUSEL_GAP,
   CONTAINER_WIDTHS,
-  INACTIVE_CARD_WIDTH,
-  MOBILE_CARD_WIDTH,
 } from './constants';
 import * as S from './style';
 
@@ -58,8 +56,9 @@ export default function ProjectSection({ mainColor }: ProjectSectionProps) {
     ? CONTAINER_WIDTHS.desktop
     : CONTAINER_WIDTHS.desktopLarge;
 
-  const activeCardWidth = isMobile ? MOBILE_CARD_WIDTH : ACTIVE_CARD_WIDTH;
-  const inactiveCardWidth = isMobile ? MOBILE_CARD_WIDTH : INACTIVE_CARD_WIDTH;
+  const cardWidths = isMobile ? CARD_WIDTHS.mobile : CARD_WIDTHS.desktop;
+  const activeCardWidth = cardWidths.active;
+  const inactiveCardWidth = cardWidths.inactive;
 
   // 중앙 정렬을 위한 translateX 계산식: 컨테이너 중앙 - (현재 인덱스 * 카드 너비 + 간격) - (활성 카드 너비 / 2)
   const translateX =
@@ -95,6 +94,7 @@ export default function ProjectSection({ mainColor }: ProjectSectionProps) {
         </S.CarouselClip>
 
         <S.NavButton
+          type="button"
           $direction="prev"
           onClick={() => goTo(currentIndex - 1)}
           aria-label="이전 프로젝트"
@@ -103,6 +103,7 @@ export default function ProjectSection({ mainColor }: ProjectSectionProps) {
         </S.NavButton>
 
         <S.NavButton
+          type="button"
           $direction="next"
           onClick={() => goTo(currentIndex + 1)}
           aria-label="다음 프로젝트"
@@ -115,6 +116,7 @@ export default function ProjectSection({ mainColor }: ProjectSectionProps) {
         {projectList.map((_, idx) => (
           <S.Indicator
             key={idx}
+            type="button"
             $active={idx === currentIndex}
             onClick={() => goTo(idx)}
             aria-label={`${idx + 1}번째 프로젝트 보기`}
@@ -122,7 +124,7 @@ export default function ProjectSection({ mainColor }: ProjectSectionProps) {
         ))}
       </S.IndicatorList>
 
-      <S.MoreButton onClick={() => router.push(PATHS.PROJECT)}>
+      <S.MoreButton type="button" onClick={() => router.push(PATHS.PROJECT)}>
         전체 프로젝트가 궁금하다면
         <S.RightArrowIcon />
       </S.MoreButton>

--- a/src/views/MainPage/components/IntroSection/ProjectSection/index.tsx
+++ b/src/views/MainPage/components/IntroSection/ProjectSection/index.tsx
@@ -1,76 +1,131 @@
 import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
-import { useIsDesktop, useIsMobile, useIsTablet } from '@src/hooks/useDevice';
-import useInView from '@src/hooks/useInView';
-import { MAIN_PROJECT_LIST } from '@src/lib/constants/project';
+import { useQuery } from '@tanstack/react-query';
+import { useState } from 'react';
+import { useMediaQuery } from 'react-responsive';
+import { api } from '@src/lib/api';
 import { PATHS } from '@src/lib/constants/routes';
-import Button from '@src/views/MainPage/components/@common/Button';
-import Project from '@src/views/MainPage/components/IntroSection/ProjectSection/Project';
+import { breakpoints } from '@src/lib/styles/breakpoints';
+import { ProjectCategoryType, ProjectPlatformType } from '@src/lib/types/project';
+import SectionTop from '@src/views/AboutPage/components/@common/SectionTop';
+import Project from './Project';
+import {
+  ACTIVE_CARD_WIDTH,
+  CAROUSEL_GAP,
+  CONTAINER_WIDTHS,
+  INACTIVE_CARD_WIDTH,
+  MOBILE_CARD_WIDTH,
+} from './constants';
 import * as S from './style';
 
 interface ProjectSectionProps {
   mainColor: string;
-  highColor: string;
 }
 
-export default function ProjectSection({ mainColor, highColor }: ProjectSectionProps) {
-  const [isGradientActive, setIsGradientActive] = useState(false);
-
+export default function ProjectSection({ mainColor }: ProjectSectionProps) {
   const router = useRouter();
-
-  const isDesktopView = useIsDesktop('1260px');
-  const isTabletView = useIsTablet('768px', '1023px');
-  const isMobileView = useIsMobile('767px');
-
-  const isSmallView = isTabletView || isMobileView;
-  const { isInView, ref: inViewRef } = useInView({
-    options: { threshold: isSmallView ? 0.5 : 0 },
+  const { data: projectData } = useQuery({
+    queryKey: ['mainAppjamProjects'],
+    queryFn: () =>
+      api.projectAPI.getProjectList(ProjectCategoryType.APPJAM, ProjectPlatformType.ALL, 1),
   });
 
-  const activateGradient = () => {
-    setIsGradientActive(true);
-  };
+  const projectList = (projectData?.data ?? []).slice(0, 5).map((p) => ({
+    thumbnail: p.thumbnailImage ?? '',
+    title: p.name,
+    category: p.serviceType[0] ?? '',
+    description: p.summary,
+    href: `${PATHS.PROJECT}/${p.id}`,
+  }));
 
-  const deactivateGradient = () => {
-    setIsGradientActive(false);
-  };
+  const [currentIndex, setCurrentIndex] = useState(0);
 
-  useEffect(() => {
-    if (!isSmallView) return;
-    if (isInView) activateGradient();
-    else deactivateGradient();
-  }, [isSmallView, isInView]);
+  // TODO: useDevice hook breakpoint 최신화 (js활용 2차 추상화 훅 추가하기)
+  const isMobile = useMediaQuery({ maxWidth: breakpoints.tablet - 1 });
+  const isTablet = useMediaQuery({
+    minWidth: breakpoints.tablet,
+    maxWidth: breakpoints.desktop - 1,
+  });
+  const isDesktop = useMediaQuery({
+    minWidth: breakpoints.desktop,
+    maxWidth: breakpoints.desktopLarge - 1,
+  });
+
+  const containerWidth = isMobile
+    ? CONTAINER_WIDTHS.mobile
+    : isTablet
+    ? CONTAINER_WIDTHS.tablet
+    : isDesktop
+    ? CONTAINER_WIDTHS.desktop
+    : CONTAINER_WIDTHS.desktopLarge;
+
+  const activeCardWidth = isMobile ? MOBILE_CARD_WIDTH : ACTIVE_CARD_WIDTH;
+  const inactiveCardWidth = isMobile ? MOBILE_CARD_WIDTH : INACTIVE_CARD_WIDTH;
+
+  // 중앙 정렬을 위한 translateX 계산식: 컨테이너 중앙 - (현재 인덱스 * 카드 너비 + 간격) - (활성 카드 너비 / 2)
+  const translateX =
+    containerWidth / 2 - currentIndex * (inactiveCardWidth + CAROUSEL_GAP) - activeCardWidth / 2;
+
+  const goTo = (index: number) => {
+    setCurrentIndex(Math.max(0, Math.min(index, projectList.length - 1)));
+  };
 
   return (
     <S.Wrapper>
-      <S.GradientOverlay
-        ref={inViewRef}
+      <SectionTop
+        engTitle="270개의 IT 서비스"
+        korTitle="매 기수 20개+의 프로젝트"
         mainColor={mainColor}
-        highColor={highColor}
-        active={isGradientActive}
-      >
-        <S.TitleWrapper>
-          <S.Title>270개의 IT 서비스</S.Title>
-          <S.Strong mainColor={mainColor}>{'매 기수\n+20개의 프로젝트'}</S.Strong>
-        </S.TitleWrapper>
+      />
 
-        <S.ProjectContainer
-          onPointerEnter={isDesktopView ? activateGradient : undefined}
-          onPointerLeave={isDesktopView ? deactivateGradient : undefined}
-        >
-          <S.ProjectList $active={isGradientActive}>
-            {MAIN_PROJECT_LIST.map((project, idx) => (
-              <Project key={`${project.title}-${idx}`} {...project} />
+      <S.CarouselSection>
+        <S.CarouselClip>
+          <S.CarouselTrack style={{ transform: `translateX(${translateX}px)` }}>
+            {projectList.map((project, idx) => (
+              <Project
+                key={`${project.title}-${idx}`}
+                thumbnail={project.thumbnail}
+                title={project.title}
+                category={project.category}
+                description={project.description}
+                isActive={idx === currentIndex}
+                href={project.href}
+              />
             ))}
-          </S.ProjectList>
+          </S.CarouselTrack>
+        </S.CarouselClip>
 
-          <S.ButtonWrapper>
-            <Button onClick={() => router.push(PATHS.PROJECT)} aria-label="프로젝트 페이지로 이동">
-              역대 프로젝트 더보기 <S.RightArrowIcon />
-            </Button>
-          </S.ButtonWrapper>
-        </S.ProjectContainer>
-      </S.GradientOverlay>
+        <S.NavButton
+          $direction="prev"
+          onClick={() => goTo(currentIndex - 1)}
+          aria-label="이전 프로젝트"
+        >
+          <S.ChevronLeft color="white" />
+        </S.NavButton>
+
+        <S.NavButton
+          $direction="next"
+          onClick={() => goTo(currentIndex + 1)}
+          aria-label="다음 프로젝트"
+        >
+          <S.ChevronRight color="white" />
+        </S.NavButton>
+      </S.CarouselSection>
+
+      <S.IndicatorList>
+        {projectList.map((_, idx) => (
+          <S.Indicator
+            key={idx}
+            $active={idx === currentIndex}
+            onClick={() => goTo(idx)}
+            aria-label={`${idx + 1}번째 프로젝트 보기`}
+          />
+        ))}
+      </S.IndicatorList>
+
+      <S.MoreButton onClick={() => router.push(PATHS.PROJECT)}>
+        전체 프로젝트가 궁금하다면
+        <S.RightArrowIcon />
+      </S.MoreButton>
     </S.Wrapper>
   );
 }

--- a/src/views/MainPage/components/IntroSection/ProjectSection/style.ts
+++ b/src/views/MainPage/components/IntroSection/ProjectSection/style.ts
@@ -1,7 +1,6 @@
 import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
 import { fontsObject } from '@sopt-makers/fonts';
-// import { ReactComponent as ChevronRightSvg } from '@src/assets/icons/chevronRight.svg';
 import { IconChevronLeft, IconChevronRight } from '@sopt-makers/icons';
 import { media } from '@src/lib/styles/breakpoints';
 import { CAROUSEL_GAP, CONTAINER_WIDTHS } from './constants';

--- a/src/views/MainPage/components/IntroSection/ProjectSection/style.ts
+++ b/src/views/MainPage/components/IntroSection/ProjectSection/style.ts
@@ -1,271 +1,168 @@
 import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
-import chevronRight from '@src/assets/icons/chevronRight.svg';
-import { convertRadialGradient } from '@src/lib/styles/gradient';
+import { fontsObject } from '@sopt-makers/fonts';
+// import { ReactComponent as ChevronRightSvg } from '@src/assets/icons/chevronRight.svg';
+import { IconChevronLeft, IconChevronRight } from '@sopt-makers/icons';
+import { media } from '@src/lib/styles/breakpoints';
+import { CAROUSEL_GAP, CONTAINER_WIDTHS } from './constants';
 
 export const Wrapper = styled.section`
-  position: relative;
   display: flex;
-  height: 100vh;
+  flex-direction: column;
   align-items: center;
-  justify-content: center;
+  gap: 48px;
+  width: 100%;
   margin: 275px 0;
 
-  /* 태블릿 뷰 */
-  @media (max-width: 1023px) {
-    height: auto;
-    min-height: 100vh;
-    margin: 180px 0;
-  }
-
-  /* 모바일 뷰 */
-  @media (max-width: 767px) {
-    margin: 180px 0;
-  }
-`;
-
-export const ProjectList = styled.div<{ $active?: boolean }>`
-  position: relative;
-  flex-shrink: 0;
-  overflow: visible;
-  width: 460px;
-  height: 430px;
-  margin-bottom: 30px;
-
-  --project-transition-duration: 500ms;
-
-  & > article {
-    position: absolute;
-    transform-origin: 50% 60%;
-    transition: transform var(--project-transition-duration) cubic-bezier(0.45, 0, 0.55, 1);
-    will-change: transform;
-  }
-
-  & > article:nth-of-type(1) {
-    top: 120px;
-    left: 60px;
-    z-index: 3;
-    transform: translateX(0) rotate(0deg);
-  }
-
-  & > article:nth-of-type(2) {
-    top: 65px;
-    left: -12.96px;
-    z-index: 2;
-    transform: translateX(0) rotate(4.31deg);
-  }
-
-  & > article:nth-of-type(3) {
-    top: -16px;
-    left: 127px;
-    z-index: 1;
-    transform: translateX(0) rotate(0deg);
-  }
-
-  & > article:nth-of-type(4) {
-    top: -40px;
-    left: -28px;
-    transform: translateX(0) rotate(-7.542deg);
-  }
-
-  /* 태블릿 뷰 */
-  @media (max-width: 1023px) {
-    width: 240px;
-    height: 260px;
-    margin-bottom: 0;
-
-    & > article:nth-of-type(1) {
-      top: 80px;
-      left: 32px;
-    }
-
-    & > article:nth-of-type(2) {
-      top: 44px;
-      left: 5px;
-    }
-
-    & > article:nth-of-type(3) {
-      top: 8px;
-      left: 48px;
-    }
-
-    & > article:nth-of-type(4) {
-      top: -30px;
-      left: 0px;
-    }
-  }
-
-  ${({ $active }) =>
-    $active
-      ? `
-    --project-transition-duration: 300ms;
-
-    & > article {
-      transform: translateX(0) rotate(0deg);
-    }
-    & > article:nth-of-type(2) {
-      transition-delay: 30ms;
-      transform: translateX(-5px) rotate(0deg);
-    }
-    & > article:nth-of-type(3) {
-      transition-delay: 30ms;
-      transform: translateY(30px) rotate(0deg);
-    }
-    & > article:nth-of-type(4) {
-      transition-delay: 60ms;
-      transform: translateX(85px) translateY(0px) rotate(0deg);
-    }
-
-    /* 태블릿 뷰 */
-    @media (max-width: 1023px) {
-      & > article:nth-of-type(2) {
-        transform: translateX(-3px) translateY(9px) rotate(0deg);
-      }
-      & > article:nth-of-type(3) {
-        transform: translateX(15px) translateY(18px) rotate(0deg);
-      }
-      & > article:nth-of-type(4) {
-        transform: translateX(28px) translateY(30px) rotate(0deg);
-      }
-    }
-  `
-      : ''}
-
-  @media (max-width: 767px) {
-    order: 1;
-  }
-`;
-
-export const GradientOverlay = styled.div<{ mainColor: string; highColor: string; active: boolean }>`
-  position: relative;
-  display: flex;
-  width: 1200px;
-  align-items: center;
-  justify-content: space-between;
-  gap: 80px;
-
-  & > * {
-    position: relative;
-    z-index: 1;
-  }
-
-
- &::before {
-    content: '';
-    position: absolute;
-    top: 65%;
-    left: 80%;
-    width: 100%;
-    height: 100%;
-    transform: translate(-50%, -50%);
-    border-radius: 999px;
-
-    background: ${({ mainColor, highColor }) => convertRadialGradient(mainColor, highColor)};
-
-    opacity: ${({ active }) => (active ? 1 : 0)};
-    filter: blur(56px);
-    transition: opacity 0.3s ease;
-    pointer-events: none;
-    z-index: 0;
-  }
-
-
-  @media (max-width: 1023px) {
-    width: 640px;
-    gap: 32px;
-
-    &::before {
-      background: ${({ mainColor, highColor }) => convertRadialGradient(mainColor, highColor)};
-    }
-  }
-
-  @media (max-width: 767px) {
-    flex-direction: column;
-    align-items: center;
-    justify-content: flex-start;
-    gap: 28px;
-
-    &::before {
-      top: 90%;
-      left: 50%;
-      background: ${({ mainColor, highColor }) => convertRadialGradient(mainColor, highColor)};
-    }
-  }
-`;
-
-export const ProjectContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 30px;
-
-  @media (max-width: 1023px) {
+  ${media.tablet} {
     gap: 24px;
+    margin: 180px 0;
   }
 
-  @media (max-width: 767px) {
-    display: contents;
-  }
-`;
-
-export const TitleWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
-
-  /* 모바일 뷰 */
-  @media (max-width: 767px) {
-    align-items: center;
-    text-align: center;
+  ${media.mobile} {
     gap: 16px;
-    order: 2;
+    margin: 180px 0;
   }
 `;
 
-export const Title = styled.p`
-  font-size: 24px;
-  font-weight: 700;
-  color: ${colors.gray100};
+export const CarouselSection = styled.div`
+  position: relative;
+  width: 100%;
+  height: 448px;
+  margin: 0 auto;
 
-  /* 태블릿 뷰 */
-  @media (max-width: 1023px) {
-    font-size: 16px;
+  ${media.desktopLarge} {
+    max-width: ${CONTAINER_WIDTHS.desktopLarge}px;
   }
 
+  ${media.desktop} {
+    max-width: ${CONTAINER_WIDTHS.desktop}px;
+  }
 
-`;
+  ${media.tablet} {
+    max-width: ${CONTAINER_WIDTHS.tablet}px;
+  }
 
-export const Strong = styled.p<{ mainColor: string }>`
-  font-size: 36px;
-  font-weight: 700;
-  line-height: 43.2px;
-  color: ${({ mainColor }) => mainColor ?? colors.gray100};
-  white-space: pre-line;
-
-  /* 태블릿 뷰 */
-  @media (max-width: 1023px) {
-    font-size: 24px;
-    line-height: 28.8px;
+  ${media.mobile} {
+    max-width: ${CONTAINER_WIDTHS.mobile}px;
+    height: auto;
   }
 `;
 
-export const RightArrowIcon = styled.i`
+export const CarouselClip = styled.div`
+  width: 100%;
+  height: 100%;
+
+  ${media.mobile} {
+    overflow: hidden;
+    height: auto;
+  }
+`;
+
+export const CarouselTrack = styled.div`
+  display: flex;
+  align-items: center;
+  height: 100%;
+  gap: ${CAROUSEL_GAP}px;
+  transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+  will-change: transform;
+`;
+
+export const NavButton = styled.button<{ $direction: 'prev' | 'next' }>`
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  ${({ $direction }) => ($direction === 'prev' ? 'left: 0;' : 'right: 0;')}
+
+  width: 32px;
+  height: 32px;
+  border-radius: 999px;
+  background-color: ${colors.gray700};
+  box-shadow: 0px 6px 20px 0px rgba(0, 0, 0, 0.2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  border: none;
+  z-index: 1;
+
+  ${media.mobile} {
+    ${({ $direction }) =>
+      $direction === 'prev' ? 'left: calc(50% - 182px);' : 'right: calc(50% - 182px);'}
+  }
+`;
+
+export const ChevronRight = styled(IconChevronRight)`
   width: 24px;
   height: 24px;
   flex-shrink: 0;
-  font-style: normal;
-  background-color: currentColor;
-  -webkit-mask-image: url(${chevronRight});
-  mask-image: url(${chevronRight});
 `;
 
-export const ButtonWrapper = styled.div`
-  display: flex;
-  justify-content: center;
+export const ChevronLeft = styled(IconChevronLeft)`
+  width: 24px;
+  height: 24px;
+  flex-shrink: 0;
+`;
 
-  /* 모바일 뷰 */
-  @media (max-width: 767px) {
-    order: 3;
-    }
+export const IndicatorList = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+`;
+
+export const Indicator = styled.button<{ $active: boolean }>`
+  height: 12px;
+  border-radius: 99px;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  transition: width 0.3s ease, background-color 0.3s ease;
+  background-color: ${({ $active }) => ($active ? colors.white : colors.gray400)};
+  width: ${({ $active }) => ($active ? '24px' : '12px')};
+
+  ${media.mobile} {
+    height: 8px;
+    width: ${({ $active }) => ($active ? '16px' : '8px')};
   }
+`;
+
+export const MoreButton = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  height: 42px;
+  padding: 12px 20px;
+  border: 1px solid ${colors.white};
+  border-radius: 10px;
+  background-color: transparent;
+  color: ${colors.white};
+  ${fontsObject.TITLE_6_16_SB}
+  white-space: nowrap;
+
+  transition: all 0.3s ease;
+  cursor: pointer;
+  &:hover {
+    background: ${colors.white};
+    color: ${colors.black};
+  }
+
+  ${media.tablet} {
+    height: 36px;
+    padding: 9px 14px;
+    border-radius: 8px;
+    ${fontsObject.LABEL_3_14_SB}
+  }
+
+  ${media.mobile} {
+    height: 36px;
+    padding: 9px 14px;
+    border-radius: 8px;
+    ${fontsObject.LABEL_3_14_SB}
+  }
+`;
+
+export const RightArrowIcon = styled(ChevronRight)`
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
 `;

--- a/src/views/MainPage/components/IntroSection/index.tsx
+++ b/src/views/MainPage/components/IntroSection/index.tsx
@@ -21,10 +21,7 @@ export default function IntroCardList({ adminData }: { adminData: GetHomepageRes
           }
         }
       />
-      <ProjectSection
-        mainColor={'#' + adminData.brandingColor.main}
-        highColor={'#' + adminData.brandingColor.high}
-      />
+      <ProjectSection mainColor={'#' + adminData.brandingColor.main} />
       <S.CoreValueSection>
         <CoreValueCardList
           cards={INTRO_CONTENT_LIST}


### PR DESCRIPTION
## Summary
- ProjectSection을 기존 스택 카드 구조에서 active/inactive 상태 기반 캐러셀로 재구현
- 캐러셀 active 카드 중앙 정렬을 위해 breakpoint별 컨테이너 너비 상수 기반으로 translateX 계산
  - DOM offsetWidth 직접 참조 → `useMediaQuery` + 고정 너비 상수로 교체 (containerRef, resize listener 제거)

## ScreenShot
https://github.com/user-attachments/assets/7976cd09-97a2-4d81-a159-717d366c01f0


## Comment
- `useDevice.ts`의 breakpoint 값이 현재 프로젝트 breakpoints 상수와 불일치 → 이후 `useMediaQuery` 기반 공통 훅으로 교체 필요 (TODO 주석 추가)

지금 jsx에서 device 판단을 위해 `const isMobile = useMediaQuery({ maxWidth: breakpoints.tablet - 1 });` 이렇게,, containerWidth 값 정의도 삼항 연산자 중첩으로 인해 조금 복잡하고 가독성이 좋지 않은 코드인데 충돌이 날 것 같아서 미디어 쿼리 2차 추상화 hook 만들게 되면 같이 리팩터링 하겠습니다,,!
