### PR TITLE
[Feat] 블로그 Select 기수 옵션 API 연동

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,17 +1,12 @@
-import { useQuery } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 import { useIsDesktop, useIsMobile, useIsTablet } from '@src/hooks/useDevice';
-import { remoteAdminAPI } from '@src/lib/api/remote/admin';
-import { GetHomepageResponse } from '@src/lib/types/admin';
+import { useHomepage } from '@src/views/MainPage/hooks/useHomepage';
 import DesktopHeader from './Desktop';
 import MobileHeader from './Mobile';
 import * as S from './style';
 
 export function Header() {
-  const { data: adminData } = useQuery<GetHomepageResponse>({
-    queryKey: ['homepage'],
-    queryFn: remoteAdminAPI.getHomepage,
-  });
+  const { data: adminData } = useHomepage();
 
   const isDesktop = useIsDesktop('58.75rem');
   const isTablet = useIsTablet('48rem', '58.6875rem');

--- a/src/hooks/useGeneration.ts
+++ b/src/hooks/useGeneration.ts
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query';
+import { remoteAdminAPI } from '@src/lib/api/remote/admin';
+import { GetHomepageResponse } from '@src/lib/types/admin';
+import { HOMEPAGE_QUERY_KEY } from '@src/views/MainPage/hooks/useHomepage';
+
+/** 현재 SOPT 기수만 가져옴 */
+export const useGeneration = (): number | null => {
+  const { data } = useQuery<GetHomepageResponse>({
+    queryKey: HOMEPAGE_QUERY_KEY,
+    queryFn: remoteAdminAPI.getHomepage,
+  });
+
+  return data?.generation ?? null;
+};

--- a/src/hooks/useGeneration.ts
+++ b/src/hooks/useGeneration.ts
@@ -1,14 +1,8 @@
-import { useQuery } from '@tanstack/react-query';
-import { remoteAdminAPI } from '@src/lib/api/remote/admin';
-import { GetHomepageResponse } from '@src/lib/types/admin';
-import { HOMEPAGE_QUERY_KEY } from '@src/views/MainPage/hooks/useHomepage';
+import { useHomepage } from '@src/views/MainPage/hooks/useHomepage';
 
 /** 현재 SOPT 기수만 가져옴 */
 export const useGeneration = (): number | null => {
-  const { data } = useQuery<GetHomepageResponse>({
-    queryKey: HOMEPAGE_QUERY_KEY,
-    queryFn: remoteAdminAPI.getHomepage,
-  });
+  const { data } = useHomepage();
 
   return data?.generation ?? null;
 };

--- a/src/lib/constants/main.ts
+++ b/src/lib/constants/main.ts
@@ -39,8 +39,9 @@ export const Activity: ActivityListType = {
     navKor: '앱잼',
     navEng: 'App jam',
     link: {
-      label: '37기 데모데이 스케치 보러 가기',
+      label: '앱잼 이야기 보러 가기',
       href: 'https://www.instagram.com/sopt_media_official/',
+      target: '_blank',
     },
     description: [
       {
@@ -54,6 +55,11 @@ export const Activity: ActivityListType = {
     img: Img솝커톤.src,
     navKor: '솝커톤',
     navEng: 'Sopkathon',
+    link: {
+      label: '솝커톤 후기 보러 가기',
+      href: '/blog?tab=review&tag=activity&activity=SOPKATHON',
+      target: '_self',
+    },
     description: [
       {
         content:
@@ -62,10 +68,15 @@ export const Activity: ActivityListType = {
       },
     ],
   },
-  [ActivityType.SOPTERM]: {
+  [ActivityType.JOIN_SEMINAR]: {
     img: Img합동세미나.src,
     navKor: '합동 세미나',
     navEng: 'Seminar',
+    link: {
+      label: '합동세미나 후기 보러 가기',
+      href: '/blog?tab=review&tag=activity&activity=SEMINAR',
+      target: '_self',
+    },
     description: [
       {
         content:

--- a/src/lib/constants/tabs.ts
+++ b/src/lib/constants/tabs.ts
@@ -35,19 +35,9 @@ export const extraTabs: ExtraTabType[] = [
 
 export const tabs = extraTabs.slice(1) as TabType[];
 
-export const activeGenerationCategoryList: number[] = [0];
-
-for (let i = 35; i >= 24; i--) {
-  activeGenerationCategoryList.push(i);
-}
-
-export const generationCategoryLabel: Record<number, string> = {
-  [0]: '전체',
-};
-
-for (let i = 35; i >= 24; i--) {
-  generationCategoryLabel[i] = `${i}기`;
-}
+export const OLDEST_GENERATION = 24;
+export const ALL_GENERATION = 0;
+export const ALL_GENERATION_LABEL = '전체';
 
 export const activitySelectLabel: Record<ActivitySelectType, string> = {
   [ActivitySelectType.ALL]: '전체 활동',

--- a/src/lib/types/main.ts
+++ b/src/lib/types/main.ts
@@ -16,7 +16,7 @@ export type TextColorType = {
 export enum ActivityType {
   APPJAM = 'APPJAM',
   SOPKATHON = 'SOPKATHON',
-  SOPTERM = 'SOPTERM',
+  JOIN_SEMINAR = 'JOIN_SEMINAR',
   STUDY = 'STUDY',
   SEMINAR = 'SEMINAR',
   EVENTS = 'EVENTS',
@@ -35,6 +35,7 @@ export enum ActivitySelectType {
 export interface ActivityLinkType {
   label: string;
   href: string;
+  target: '_blank' | '_self';
 }
 
 export interface ActivityContentType {
@@ -53,7 +54,7 @@ export const activity: ActivityTypeList[] = [
     value: ActivityType.SOPKATHON,
   },
   {
-    value: ActivityType.SOPTERM,
+    value: ActivityType.JOIN_SEMINAR,
   },
   {
     value: ActivityType.EVENTS,

--- a/src/views/BlogPage/components/BlogTab/index.tsx
+++ b/src/views/BlogPage/components/BlogTab/index.tsx
@@ -1,15 +1,15 @@
 import { track } from '@amplitude/analytics-browser';
 import Select from '@src/components/common/Select';
 import {
-  activeGenerationCategoryList,
+  ALL_GENERATION,
   activePartCategoryList,
   activities,
   activitySelectLabel,
-  generationCategoryLabel,
   partCategoryLabel,
 } from '@src/lib/constants/tabs';
 import { PartCategoryType } from '@src/lib/types/blog';
 import { ActivitySelectType } from '@src/lib/types/main';
+import useGenerationCategories from '@src/views/BlogPage/hooks/useGenerationCategories';
 import * as S from './style';
 import { BlogTabMap, BlogTabType, SelectedType } from './types';
 
@@ -31,6 +31,8 @@ export default function BlogTab({
   setSelectedActivity,
 }: BlogTabProps) {
   const { selectedTab, selectedMajorCategory, selectedSubCategory, selectedActivity } = selected;
+
+  const { options: generationOptions, labels: generationLabels } = useGenerationCategories();
 
   const handleTagClick = (tag: SelectedType['tag']) => {
     if (selected.tag === tag) return;
@@ -99,12 +101,12 @@ export default function BlogTab({
                 </S.TagContainer>
                 <S.SelectContainer>
                   <Select
-                    options={activeGenerationCategoryList}
-                    labels={generationCategoryLabel}
+                    options={generationOptions}
+                    labels={generationLabels}
                     baseLabel="기수"
                     selectedValue={selectedMajorCategory}
                     setSelectedValue={setMajorCategory}
-                    baseValue={activeGenerationCategoryList[0]}
+                    baseValue={ALL_GENERATION}
                     variant="square"
                   />
                   <Select

--- a/src/views/BlogPage/components/EmptyBlogPostList/index.tsx
+++ b/src/views/BlogPage/components/EmptyBlogPostList/index.tsx
@@ -1,4 +1,4 @@
-import { activeGenerationCategoryList } from '@src/lib/constants/tabs';
+import { ALL_GENERATION } from '@src/lib/constants/tabs';
 import { BlogCategoryType, PartCategoryType } from '@src/lib/types/blog';
 import { ActivitySelectType } from '@src/lib/types/main';
 import { BlogTabType, SelectedType } from '../BlogTab/types';
@@ -30,7 +30,7 @@ export default function EmptyBlogPostList({
   const showTotalApplyReview = () => {
     setSelected({
       ...selected,
-      selectedMajorCategory: activeGenerationCategoryList[0],
+      selectedMajorCategory: ALL_GENERATION,
       selectedSubCategory: PartCategoryType.ALL,
     });
   };
@@ -39,7 +39,7 @@ export default function EmptyBlogPostList({
     setSelected({
       ...selected,
       selectedActivity: ActivitySelectType.ALL,
-      selectedMajorCategory: activeGenerationCategoryList[0],
+      selectedMajorCategory: ALL_GENERATION,
       selectedSubCategory: PartCategoryType.ALL,
     });
   };

--- a/src/views/BlogPage/hooks/useApplyBlogQueryParams.ts
+++ b/src/views/BlogPage/hooks/useApplyBlogQueryParams.ts
@@ -1,0 +1,54 @@
+import { useRouter } from 'next/router';
+import { useEffect, useRef } from 'react';
+import { ActivitySelectType } from '@src/lib/types/main';
+import type { ParsedUrlQuery } from 'querystring';
+import { BlogTabType, SelectedType } from '../components/BlogTab/types';
+
+const REVIEW_TAGS = ['recruit', 'activity'] as const;
+
+type QueryParamValue = string | string[] | undefined;
+type ReviewTag = (typeof REVIEW_TAGS)[number];
+
+const toBlogTab = (raw: QueryParamValue) => Object.values(BlogTabType).find((tab) => tab === raw);
+
+const toReviewTag = (raw: QueryParamValue) => REVIEW_TAGS.find((tag) => tag === raw);
+
+const toActivity = (raw: QueryParamValue) => {
+  if (typeof raw !== 'string' || !(raw in ActivitySelectType)) return undefined;
+
+  return ActivitySelectType[raw as keyof typeof ActivitySelectType];
+};
+
+const readSelectedFromQuery = (query: ParsedUrlQuery) => {
+  const selectedTab = toBlogTab(query.tab);
+  const tag = toReviewTag(query.tag);
+  const selectedActivity = toActivity(query.activity);
+
+  return {
+    ...(selectedTab && { selectedTab }),
+    ...(tag && { tag }),
+    ...(selectedActivity && { selectedActivity }),
+  };
+};
+
+/** Activity Carousel에서 특정 활동 후기로 진입할 때 사용 */
+const useApplyBlogQueryParams = (
+  selected: SelectedType,
+  setSelected: (value: SelectedType) => void,
+) => {
+  const router = useRouter();
+  const didApplyQuery = useRef(false);
+
+  useEffect(() => {
+    if (!router.isReady || didApplyQuery.current) return;
+    didApplyQuery.current = true;
+
+    const selectedFromQuery = readSelectedFromQuery(router.query);
+    if (Object.keys(selectedFromQuery).length === 0) return;
+
+    setSelected({ ...selected, ...selectedFromQuery });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [router.isReady]);
+};
+
+export default useApplyBlogQueryParams;

--- a/src/views/BlogPage/hooks/useGenerationCategories.ts
+++ b/src/views/BlogPage/hooks/useGenerationCategories.ts
@@ -3,19 +3,16 @@ import { ALL_GENERATION, ALL_GENERATION_LABEL, OLDEST_GENERATION } from '@src/li
 
 const useGenerationCategories = () => {
   const latestGeneration = useGeneration();
-  const generations = [];
+
+  const options = [ALL_GENERATION];
+  const labels: Record<number, string> = { [ALL_GENERATION]: ALL_GENERATION_LABEL };
 
   if (latestGeneration) {
     for (let generation = latestGeneration; generation >= OLDEST_GENERATION; generation--) {
-      generations.push(generation);
+      options.push(generation);
+      labels[generation] = `${generation}기`;
     }
   }
-
-  const options = [ALL_GENERATION, ...generations];
-  const labels: Record<number, string> = {
-    [ALL_GENERATION]: ALL_GENERATION_LABEL,
-    ...Object.fromEntries(generations.map((generation) => [generation, `${generation}기`])),
-  };
 
   return { options, labels };
 };

--- a/src/views/BlogPage/hooks/useGenerationCategories.ts
+++ b/src/views/BlogPage/hooks/useGenerationCategories.ts
@@ -1,0 +1,23 @@
+import { useGeneration } from '@src/hooks/useGeneration';
+import { ALL_GENERATION, ALL_GENERATION_LABEL, OLDEST_GENERATION } from '@src/lib/constants/tabs';
+
+const useGenerationCategories = () => {
+  const latestGeneration = useGeneration();
+  const generations = [];
+
+  if (latestGeneration) {
+    for (let generation = latestGeneration; generation >= OLDEST_GENERATION; generation--) {
+      generations.push(generation);
+    }
+  }
+
+  const options = [ALL_GENERATION, ...generations];
+  const labels: Record<number, string> = {
+    [ALL_GENERATION]: ALL_GENERATION_LABEL,
+    ...Object.fromEntries(generations.map((generation) => [generation, `${generation}기`])),
+  };
+
+  return { options, labels };
+};
+
+export default useGenerationCategories;

--- a/src/views/BlogPage/index.tsx
+++ b/src/views/BlogPage/index.tsx
@@ -11,6 +11,7 @@ import BlogPostList from '@src/views/BlogPage/components/BlogPostList';
 import BlogPostSkeletonUI from '@src/views/BlogPage/components/BlogPostSkeletonUI';
 import BlogTab from '@src/views/BlogPage/components/BlogTab';
 import { BlogTabType, SelectedType } from './components/BlogTab/types';
+import useApplyBlogQueryParams from './hooks/useApplyBlogQueryParams';
 
 const initialState: SelectedType = {
   selectedTab: BlogTabType.REVIEW,
@@ -31,6 +32,8 @@ export default function BlogPage() {
     'sessionStorage',
     SortType.LATEST,
   );
+
+  useApplyBlogQueryParams(selected, setSelected);
 
   const updateSelected = <K extends keyof SelectedType>(key: K, value: SelectedType[K]) => {
     setSelected({

--- a/src/views/BlogPage/index.tsx
+++ b/src/views/BlogPage/index.tsx
@@ -3,7 +3,7 @@ import { css } from '@emotion/react';
 import { Suspense } from 'react';
 import PageLayout from '@src/components/common/PageLayout';
 import useStorage from '@src/hooks/useStorage';
-import { activeGenerationCategoryList } from '@src/lib/constants/tabs';
+import { ALL_GENERATION } from '@src/lib/constants/tabs';
 import { PartCategoryType, SortType } from '@src/lib/types/blog';
 import { ActivitySelectType } from '@src/lib/types/main';
 import Banner from '@src/views/BlogPage/components/Banner';
@@ -14,7 +14,7 @@ import { BlogTabType, SelectedType } from './components/BlogTab/types';
 
 const initialState: SelectedType = {
   selectedTab: BlogTabType.REVIEW,
-  selectedMajorCategory: activeGenerationCategoryList[0],
+  selectedMajorCategory: ALL_GENERATION,
   selectedSubCategory: PartCategoryType.ALL,
   selectedActivity: ActivitySelectType.ALL,
   tag: 'recruit',

--- a/src/views/MainPage/components/Activity/ActivityCarousel/ActivityCard/index.tsx
+++ b/src/views/MainPage/components/Activity/ActivityCarousel/ActivityCard/index.tsx
@@ -27,7 +27,7 @@ export default function ActivityCard({ img, navKor, navEng, description, link }:
             theme="black"
             rounded="lg"
             RightIcon={IconChevronRight}
-            onClick={() => window.open(link.href, '_blank')}
+            onClick={() => window.open(link.href, link.target)}
           >
             {link.label}
           </Button>

--- a/src/views/MainPage/hooks/useHomepage.ts
+++ b/src/views/MainPage/hooks/useHomepage.ts
@@ -2,11 +2,9 @@ import { useQuery } from '@tanstack/react-query';
 import { remoteAdminAPI } from '@src/lib/api/remote/admin';
 import { GetHomepageResponse } from '@src/lib/types/admin';
 
-export const HOMEPAGE_QUERY_KEY = ['homepage'] as const;
-
 export const useHomepage = () => {
   return useQuery<GetHomepageResponse>({
-    queryKey: HOMEPAGE_QUERY_KEY,
+    queryKey: ['homepage'],
     queryFn: remoteAdminAPI.getHomepage,
   });
 };

--- a/src/views/MainPage/hooks/useHomepage.ts
+++ b/src/views/MainPage/hooks/useHomepage.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import { remoteAdminAPI } from '@src/lib/api/remote/admin';
+import { GetHomepageResponse } from '@src/lib/types/admin';
+
+export const HOMEPAGE_QUERY_KEY = ['homepage'] as const;
+
+export const useHomepage = () => {
+  return useQuery<GetHomepageResponse>({
+    queryKey: HOMEPAGE_QUERY_KEY,
+    queryFn: remoteAdminAPI.getHomepage,
+  });
+};

--- a/src/views/MainPage/index.tsx
+++ b/src/views/MainPage/index.tsx
@@ -1,8 +1,6 @@
-import { useQuery } from '@tanstack/react-query';
 import { useEffect, useMemo } from 'react';
 import PageLayout from '@src/components/common/PageLayout';
-import { remoteAdminAPI } from '@src/lib/api/remote/admin';
-import { GetHomepageResponse } from '@src/lib/types/admin';
+import { useHomepage } from '@src/views/MainPage/hooks/useHomepage';
 import AboutSOPTSection from '@src/views/MainPage/components/AboutSOPTSection';
 import IntroSection from '@src/views/MainPage/components/IntroSection';
 import TopBanner from '@src/views/MainPage/components/TopBanner';
@@ -12,10 +10,7 @@ import Banner from './components/Banner';
 import Introduce from './components/Introduce';
 
 function MainPage() {
-  const { data: adminData } = useQuery<GetHomepageResponse>({
-    queryKey: ['homepage'],
-    queryFn: remoteAdminAPI.getHomepage,
-  });
+  const { data: adminData } = useHomepage();
 
   const isOBRecruiting = checkIsTimeInRange(
     adminData?.recruitSchedule[0].schedule.applicationStartTime ?? '',


### PR DESCRIPTION
## Summary

- [x] Blog 탭 내 기수 Select 값을 API에서 내려주는 `generation` 값으로 변경 (기존에는 하드코딩 되어 있었음)
- [x] 내려주는 `generation` 기반으로 값을 리턴하는 `useGenerationCategories` 훅 추가
- [x] 현재 기수를 API 응답에서 가져오는 `useGeneration` 훅 및 관련 상수 분리
- [x] Activity Carousel의 버튼을 클릭하면 블로그 탭의 특정 카테고리로 라우팅


## Screenshot

<img width="209" height="456" alt="스크린샷 2026-05-27 오후 11 54 39" src="https://github.com/user-attachments/assets/10b79049-666a-4a2b-8bd0-600a923b9d92" />


