### PR TITLE
[Feat] 파트 링크 지원서 페이지 파트 상세로 변경

### DIFF
--- a/src/views/MainPage/components/PartIntroduction/index.tsx
+++ b/src/views/MainPage/components/PartIntroduction/index.tsx
@@ -1,7 +1,7 @@
 import { Ref, forwardRef } from 'react';
 import { useIsMobile, useIsTablet } from '@src/hooks/useDevice';
 import { PART_NAMES } from '@src/lib/constants/main';
-import { PATHS } from '@src/lib/constants/routes';
+import { RECRUIT_URL } from '@src/lib/constants/routes';
 import { breakpoints } from '@src/lib/styles/breakpoints';
 import * as S from './style';
 
@@ -68,7 +68,7 @@ const PartItem = ({ partIntro, mainColor }: ItemProps) => {
 
   return (
     <S.PartItem>
-      <S.Link href={PATHS.ABOUT}>
+      <S.Link href={`${RECRUIT_URL}/part/${PART_NAMES[partIntro.part]}`}>
         <S.HoverIconBadge aria-hidden="true" mainColor={mainColor}>
           <S.HoverIcon />
         </S.HoverIconBadge>


### PR DESCRIPTION
## Summary
파트 링크 지원서 페이지 파트 상세로 변경

기존 공식 홈페이지 파트 카드 링크가 공홈 내부 소개탭으로 연결되었는데, 이를 지원서 페이지의 파트 상세 페이지로 변경하였습니다.

